### PR TITLE
TOBAGO-1666 tc:selectBooleanCheckbox: itemLabel with accessKey

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SelectBooleanCheckboxRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SelectBooleanCheckboxRenderer.java
@@ -128,7 +128,11 @@ public class SelectBooleanCheckboxRenderer extends MessageLayoutRendererBase {
     writer.writeClassAttribute(TobagoClass.INPUT_PSEUDO);
     writer.endElement(HtmlElements.I);
 
-    if (itemLabel != null) {
+    if (itemLabel != null && select.getLabel() == null && select.getAccessKey() != null) {
+      if (itemLabel.contains(Character.toString(select.getAccessKey()))) {
+        HtmlRendererUtils.writeLabelWithAccessKey(writer, label);
+      }
+    } else if (itemLabel != null) {
       writer.writeText(itemLabel);
     }
   }

--- a/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-dropdown.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-dropdown.ts
@@ -128,7 +128,7 @@ class Dropdown extends HTMLElement {
   }
 
   openDropdown(): void {
-    this.dispatchEvent(new CustomEvent(Event.HIDE));
+    this.dispatchEvent(new CustomEvent(Event.SHOW));
 
     if (!this.inStickyHeader()) {
       this.menuStore.appendChild(this.dropdownMenu);
@@ -142,14 +142,14 @@ class Dropdown extends HTMLElement {
     }
 
     this.dropdownMenu.classList.add("show");
-    this.dispatchEvent(new CustomEvent(Event.HIDDEN));
+    this.dispatchEvent(new CustomEvent(Event.SHOWN));
   }
 
   closeDropdown(): void {
-    this.dispatchEvent(new CustomEvent(Event.SHOW));
+    this.dispatchEvent(new CustomEvent(Event.HIDE));
     this.dropdownMenu.classList.remove("show");
     this.appendChild(this.dropdownMenu);
-    this.dispatchEvent(new CustomEvent(Event.SHOWN));
+    this.dispatchEvent(new CustomEvent(Event.HIDDEN));
   }
 
   private get toggleButton(): HTMLElement {


### PR DESCRIPTION
If the itemLabel and the accessKey are set, there is no label and the accessKey is contained in the itemLabel, then the itemLabel with the underlined accessKey should be written within one u-tag. Otherwise only the itemLabel is written