### PR TITLE
tc:selectBooleanCheckbox: itemLabel with accessKey

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SelectBooleanCheckboxRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SelectBooleanCheckboxRenderer.java
@@ -128,7 +128,11 @@ public class SelectBooleanCheckboxRenderer extends MessageLayoutRendererBase {
     writer.writeClassAttribute(TobagoClass.INPUT_PSEUDO);
     writer.endElement(HtmlElements.I);
 
-    if (itemLabel != null) {
+    if (itemLabel != null && select.getLabel() == null && select.getAccessKey() != null) {
+      if (itemLabel.contains(Character.toString(select.getAccessKey()))) {
+        HtmlRendererUtils.writeLabelWithAccessKey(writer, label);
+      }
+    } else if (itemLabel != null) {
       writer.writeText(itemLabel);
     }
   }


### PR DESCRIPTION
The accessKey is shown on the label by default. But if only an itemLabel is set, the accessKey is shown on the itemLabel.
itemLabel works also for tc:selectBooleanToggle

Issue: TOBAGO-1666