### PR TITLE
tc:out: improve input group example

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/GroupController.java
+++ b/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/GroupController.java
@@ -43,6 +43,8 @@ public class GroupController implements Serializable {
   private double valueInEuro;
   private Currency currency;
   private static final Currency[] CURRENCIES;
+  private String firstName;
+  private String lastName;
 
   static {
     CURRENCIES = new Currency[]{
@@ -58,6 +60,8 @@ public class GroupController implements Serializable {
     sendTo = "";
     value = 1000.0;
     currency = Currency.getInstance("EUR");
+    firstName = "Bob";
+    lastName = "Marley";
     compute();
   }
 
@@ -156,4 +160,12 @@ public class GroupController implements Serializable {
   public Currency[] getCurrencies() {
     return CURRENCIES;
   }
+
+  public String getFirstName() { return firstName; }
+
+  public void setFirstName(String firstName) { this.firstName = firstName; }
+
+  public String getLastName() { return lastName; }
+
+  public void setLastName(String lastName) { this.lastName = lastName; }
 }

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/010-input/50-input-group/Group.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/010-input/50-input-group/Group.xhtml
@@ -53,14 +53,14 @@
       <p>The following example show, how to add twice tc:out on one side in an input group</p>
       <pre><code class="language-markup"> &lt;tc:in id="values">
   &lt;f:facet name="before">
-    &lt;tc:out id="valueFirstName" value="#{groupController.firstName}"/>
-    &lt;tc:out id="valueLastName" value="#{groupController.lastName}"/>
+    &lt;tc:out id="firstName" value="#{groupController.firstName}"/>
+    &lt;tc:out id="lastName" value="#{groupController.lastName}"/>
   &lt;/f:facet>
 &lt;/tc:in></code></pre>
       <tc:in id="values">
         <f:facet name="before">
-          <tc:out id="valueFirstName" value="#{groupController.firstName}"/>
-          <tc:out id="valueLastName" value="#{groupController.lastName}"/>
+          <tc:out id="firstName" value="#{groupController.firstName}"/>
+          <tc:out id="lastName" value="#{groupController.lastName}"/>
         </f:facet>
       </tc:in>
     </tc:section>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/010-input/50-input-group/Group.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/010-input/50-input-group/Group.xhtml
@@ -49,6 +49,21 @@
         <f:facet name="after">.00 €</f:facet>
       </tc:in>
     </tc:section>
+    <tc:section label="Output">
+      <p>The following example show, how to add twice tc:out on one side in an input group</p>
+      <pre><code class="language-markup"> &lt;tc:in id="values">
+  &lt;f:facet name="before">
+    &lt;tc:out id="valueFirstName" value="#{groupController.firstName}"/>
+    &lt;tc:out id="valueLastName" value="#{groupController.lastName}"/>
+  &lt;/f:facet>
+&lt;/tc:in></code></pre>
+      <tc:in id="values">
+        <f:facet name="before">
+          <tc:out id="valueFirstName" value="#{groupController.firstName}"/>
+          <tc:out id="valueLastName" value="#{groupController.lastName}"/>
+        </f:facet>
+      </tc:in>
+    </tc:section>
   </tc:section>
 
   <tc:section label="Commands">


### PR DESCRIPTION
The example shows, how to use twice labels in an input group. It is possible to have more than one label on one side of an input group. The multiple tc:out is located inside the f:facet and the f:facet is inside the tc:in.

Issue: TOBAGO-1843