### PR TITLE
Bar custom component

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/BarRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/BarRenderer.java
@@ -54,12 +54,11 @@ public class BarRenderer extends RendererBase {
     final String navbarId = clientId + "::navbar";
     final Markup markup = bar.getMarkup();
 
-    writer.startElement(HtmlElements.NAV);
+    writer.startElement(HtmlElements.TOBAGO_BAR);
     writer.writeIdAttribute(clientId);
     writer.writeClassAttribute(
-        TobagoClass.BAR,
-        TobagoClass.BAR.createMarkup(bar.getMarkup()),
         BootstrapClass.NAVBAR,
+        TobagoClass.BAR.createMarkup(bar.getMarkup()),
         getNavbarExpand(markup),
         getNavbarColorScheme(markup),
         bar.getCustomClass());
@@ -143,7 +142,7 @@ public class BarRenderer extends RendererBase {
       writer.endElement(HtmlElements.DIV);
     }
     writer.endElement(HtmlElements.DIV);
-    writer.endElement(HtmlElements.NAV);
+    writer.endElement(HtmlElements.TOBAGO_BAR);
   }
 
   private void encodeOpener(

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/BarRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/BarRenderer.java
@@ -115,7 +115,7 @@ public class BarRenderer extends RendererBase {
     }
   }
 
-  private void setRenderTypes(final UIComponent component) throws IOException {
+  private void setRenderTypes(final UIComponent component) {
     for (final UIComponent child : component.getChildren()) {
       if (child.isRendered()) {
         if (child instanceof AbstractUIForm) {

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/renderkit/html/HtmlElements.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/renderkit/html/HtmlElements.java
@@ -133,6 +133,7 @@ public enum HtmlElements {
   VIDEO("video"),
   WBR("wbr", Qualifier.VOID),
 
+  TOBAGO_BAR("tobago-bar"),
   TOBAGO_BEHAVIOR("tobago-behavior"),
   TOBAGO_DATE("tobago-date"),
   TOBAGO_DROPDOWN("tobago-dropdown"),

--- a/tobago-core/src/main/resources/scss/_tobago.scss
+++ b/tobago-core/src/main/resources/scss/_tobago.scss
@@ -114,7 +114,11 @@ $form-disabled-alpha: 0.5;
 }
 
 /* bar -------------------------------------------------------------- */
+// todo: remove CSS class
 .tobago-bar {
+}
+
+tobago-bar {
   &.navbar-light .navbar-brand > .tobago-link {
     color: $navbar-light-active-color;
 

--- a/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-all.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-all.ts
@@ -16,6 +16,7 @@
  */
 
 import "./tobago-listener";
+import "./tobago-bar";
 import "./tobago-core";
 import "./tobago-dropdown";
 // import "@vaadin/vaadin-date-picker";

--- a/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-bar.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-bar.ts
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {DomUtils} from "./tobago-utils";
+
+class Bar extends HTMLElement {
+
+  private readonly CssClass = {
+    SHOW: "show",
+    COLLAPSE: "collapse",
+    COLLAPSING: "collapsing"
+  };
+  private readonly ariaExpanded: string = "aria-expanded";
+  private timeout: number;
+  private expanded: boolean;
+
+  constructor() {
+    super();
+    this.toggleButton.addEventListener("click", this.toggleCollapse.bind(this));
+  }
+
+  connectedCallback(): void {
+    this.expanded = this.toggleButton.getAttribute(this.ariaExpanded) === "true";
+  }
+
+  private toggleCollapse(event: MouseEvent): void {
+    window.clearTimeout(this.timeout);
+
+    if (this.expanded) {
+      this.expanded = false;
+      this.navbarContent.style.height = this.navbarContent.scrollHeight + "px";
+      this.navbarContent.offsetHeight; //force reflow, to make sure height is set
+      this.navbarContent.classList.add(this.CssClass.COLLAPSING);
+      this.navbarContent.classList.remove(this.CssClass.COLLAPSE);
+      this.navbarContent.classList.remove(this.CssClass.SHOW);
+      this.navbarContent.style.height = null;
+
+      this.timeout = window.setTimeout(() => {
+        this.navbarContent.classList.remove(this.CssClass.COLLAPSING);
+        this.navbarContent.classList.add(this.CssClass.COLLAPSE);
+        this.toggleButton.setAttribute(this.ariaExpanded, "false");
+      }, DomUtils.getTransitionTime(this.navbarContent));
+    } else {
+      this.expanded = true;
+      this.navbarContent.classList.remove(this.CssClass.COLLAPSE);
+      this.navbarContent.classList.add(this.CssClass.COLLAPSING);
+      this.navbarContent.style.height = this.navbarContent.scrollHeight + "px";
+
+      this.timeout = window.setTimeout(() => {
+        this.navbarContent.classList.remove(this.CssClass.COLLAPSING);
+        this.navbarContent.classList.add(this.CssClass.COLLAPSE);
+        this.navbarContent.classList.add(this.CssClass.SHOW);
+        this.navbarContent.style.height = null;
+        this.toggleButton.setAttribute(this.ariaExpanded, "true");
+      }, DomUtils.getTransitionTime(this.navbarContent));
+    }
+  }
+
+  private get toggleButton(): HTMLButtonElement {
+    const root = this.getRootNode() as ShadowRoot | Document;
+    return root.querySelector(".navbar-toggler");
+  }
+
+  private get navbarContent(): HTMLDivElement {
+    const root = this.getRootNode() as ShadowRoot | Document;
+    return root.querySelector(".navbar-collapse");
+  }
+}
+
+document.addEventListener("DOMContentLoaded", function (event: Event): void {
+  window.customElements.define("tobago-bar", Bar);
+});

--- a/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-popup.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-popup.ts
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
+import {DomUtils} from "./tobago-utils";
+
 const ESCAPE_KEYCODE = 27; // KeyboardEvent.which value for Escape (Esc) key
-const MILLISECONDS_MULTIPLIER = 1000;
 
 const Default = {
   backdrop: true,
@@ -252,7 +253,7 @@ export class Popup extends HTMLElement {
 
       this._element.classList.add(ClassName.STATIC);
 
-      const modalTransitionDuration = Util.getTransitionDurationFromElement(this._element)
+      const modalTransitionDuration = DomUtils.getTransitionTime(this._element)
 
       $(this._element).one(Util.TRANSITION_END, () => {
         this._element.classList.remove(ClassName.STATIC)
@@ -303,7 +304,7 @@ export class Popup extends HTMLElement {
     // };
 
     // if (transition) {
-    //   const transitionDuration = Util.getTransitionDurationFromElement(this._dialog)
+    //   const transitionDuration = DomUtils.getTransitionTime(this._dialog)
     //
     //   $(this._dialog)
     //       .one(Util.TRANSITION_END, transitionComplete)
@@ -405,7 +406,7 @@ export class Popup extends HTMLElement {
         return;
       }
 
-      const backdropTransitionDuration: number = this.getTransitionDurationFromElement(this._backdrop);
+      const backdropTransitionDuration: number = DomUtils.getTransitionTime(this._backdrop);
 
       this.addOnetimeEventListener(this._backdrop, Event.TRANSITION_END, callback);
       this.emulateTransitionEnd(this._backdrop, backdropTransitionDuration);
@@ -420,7 +421,7 @@ export class Popup extends HTMLElement {
       };
 
       if (this.classList.contains(ClassName.FADE)) {
-        const backdropTransitionDuration = this.getTransitionDurationFromElement(this._backdrop);
+        const backdropTransitionDuration = DomUtils.getTransitionTime(this._backdrop);
 
         this.addOnetimeEventListener(this._backdrop, Event.TRANSITION_END, callbackRemove);
         this.emulateTransitionEnd(this._backdrop, backdropTransitionDuration);
@@ -556,13 +557,6 @@ export class Popup extends HTMLElement {
       }
     })
   }*/
-
-  private getTransitionDurationFromElement(element: HTMLDivElement): number {
-    const computedStyle = getComputedStyle(element);
-    let transitionDuration: number = parseFloat(computedStyle.transitionDuration);
-    let transitionDelay: number = parseFloat(computedStyle.transitionDelay);
-    return (transitionDuration + transitionDelay) * MILLISECONDS_MULTIPLIER;
-  }
 
   private emulateTransitionEnd(element: HTMLElement, duration: number): void {
     this.emulateTransitionEndCalled = false;

--- a/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-utils.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-utils.ts
@@ -156,4 +156,15 @@ export class DomUtils {
     }
     return id.substring(0, id.lastIndexOf(DomUtils.COMPONENT_SEP));
   }
+
+  /**
+   * @param element with transition
+   * @return transition time in milliseconds
+   */
+  static getTransitionTime(element: HTMLElement): number {
+    const style = getComputedStyle(element);
+    let delay: number = parseFloat(style.transitionDelay);
+    let duration: number = parseFloat(style.transitionDuration);
+    return (delay + duration) * 1000;
+  }
 }


### PR DESCRIPTION
The event listener is defined in the constructor because changes on the DOM can trigger DOMContentLoaded events. In this case the event listener is registered twice. (See tobago-dropdown.ts)

I've create an CssClass enum and a readonly variable, to prevent misspelling. Is this best practise or should we use just strings?
