### PR TITLE
TOBAGO-2023: An anchor href with mailto: entry must not use + to esca…

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/OperationTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/OperationTagDeclaration.java
@@ -46,14 +46,14 @@ public interface OperationTagDeclaration {
   /**
    * Name of the operation to be executed.
    */
-  @TagAttribute()
+  @TagAttribute(required = true)
   @UIComponentTagAttribute()
   void setName(String name);
 
   /**
    * The id of the component the operation is related to.
    */
-  @TagAttribute()
+  @TagAttribute(required = true)
   @UIComponentTagAttribute()
   void setFor(String forAttribute);
 

--- a/tobago-core/src/test/java/org/apache/myfaces/tobago/internal/util/RenderUtilsUnitTest.java
+++ b/tobago-core/src/test/java/org/apache/myfaces/tobago/internal/util/RenderUtilsUnitTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.myfaces.tobago.internal.util;
+
+import org.apache.myfaces.tobago.component.UILink;
+import org.apache.myfaces.tobago.internal.config.AbstractTobagoTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.faces.component.UIParameter;
+
+public class RenderUtilsUnitTest extends AbstractTobagoTestBase {
+
+  @Test
+  public void simple() {
+    final UILink link = new UILink();
+    link.setLink("local.xhtml");
+    final String url = RenderUtils.generateUrl(getFacesContext(), link);
+    Assert.assertEquals("local.xhtml", url);
+  }
+
+  @Test
+  public void mailto() {
+    final UILink link = new UILink();
+    link.setLink("mailto:MyFaces Discussion <users@myfaces.apache.org>");
+
+    final UIParameter subject = new UIParameter();
+    subject.setName("subject");
+    subject.setValue("[Tobago] Preparation for the 5.0.0 release");
+    link.getChildren().add(subject);
+
+    final UIParameter body = new UIParameter();
+    body.setName("body");
+    body.setValue("Hi, folks,\n"
+        + "\n"
+          + "we plan to build version 5.0.0 of Tobago soon.");
+    link.getChildren().add(body);
+
+    final String url = RenderUtils.generateUrl(getFacesContext(), link);
+    Assert.assertEquals("mailto:MyFaces Discussion <users@myfaces.apache.org>"
+        + "?subject=%5BTobago%5D%20Preparation%20for%20the%205.0.0%20release"
+        + "&body=Hi%2C%20folks%2C%0A%0Awe%20plan%20to%20build%20version%205.0.0%20of%20Tobago%20soon.", url);
+  }
+}

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/10-intro/90-release-checklist/release-checklist.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/10-intro/90-release-checklist/release-checklist.xhtml
@@ -30,7 +30,7 @@
     <tc:section label="Step by Step">
 
       Checklist of tasks to perform for each release. For general information about Apache releases you may also consult
-      <tc:link label="Publishing Maven Artifacts" link="http://www.apache.org/dev/publishing-maven-artifacts.html"
+      <tc:link label="Publishing Maven Releases" link="http://infra.apache.org/maven-releases.html"
                image="fa-external-link"/>.
 
       <tc:section label="Preparation">
@@ -45,8 +45,11 @@
 
           <li>Ensure that all open bugs and issues in
             <tc:link label="Jira"
-                     link="https://issues.apache.org/jira/issues/?jql=project%20%3D%20TOBAGO%20AND%20fixVersion%20%3D%20#{apiController.releases[0].version}"
-                     image="fa-external-link"/> have been either fixed
+                     link="https://issues.apache.org/jira/issues/"
+                     image="fa-external-link">
+              <f:param name="jql" value="project = TOBAGO AND fixVersion = #{apiController.releases[0].version}"/>
+            </tc:link>
+            have been either fixed
             or moved to an other release version.
           </li>
 
@@ -63,6 +66,11 @@
             and ask for problems with the release candidate.
             <tc:popup markup="large" collapsedMode="hidden" id="preparation-email">
               <tc:box label="Preparation email">
+                <f:facet name="bar">
+                  <tc:button image="fa-close" tip="Close" omit="true">
+                    <tc:operation name="hide" for="preparation-email"/>
+                  </tc:button>
+                </f:facet>
                 <i>Replace the variable part &lt;sender-name></i>.
                 <tc:separator/>
                 <c:set var="subject" value="[Tobago] Preparation for the #{apiController.releases[0].version} release"/>
@@ -197,6 +205,11 @@ $ mvn release:perform
             </tc:link> with the staging location.
             <tc:popup markup="large" collapsedMode="hidden" id="vote-email">
               <tc:box label="Voting email">
+                <f:facet name="bar">
+                  <tc:button image="fa-close" tip="Close" omit="true">
+                    <tc:operation name="hide" for="vote-email"/>
+                  </tc:button>
+                </f:facet>
                 <i>Replace the variable part &lt;sender-name>, &lt;insert-list>, &lt;use-one-of>, &lt;a>, &lt;b>or, &lt;c>, &lt;id-from-nexus></i>.
                 <tc:separator/>
                 <c:set var="subject" value="[VOTE] Release Tobago #{apiController.releases[0].version}"/>
@@ -338,6 +351,11 @@ $ mvn site:stage -DstagingDirectory=$TOBAGO_SITE/tobago-publish</code></pre>
             </tc:link>.
             <tc:popup markup="large" collapsedMode="hidden" id="announcement-email">
               <tc:box label="Announcement email">
+                <f:facet name="bar">
+                  <tc:button image="fa-close" tip="Close" omit="true">
+                    <tc:operation name="hide" for="announcement-email"/>
+                  </tc:button>
+                </f:facet>
                 <i>Replace the variable parts &lt;edit-me></i>.
                 <tc:separator/>
                 <c:set var="subject" value="[ANNOUNCE] Apache Tobago #{apiController.releases[0].version} released"/>

--- a/tobago-example/tobago-example-demo/src/main/webapp/script/demo.js
+++ b/tobago-example/tobago-example-demo/src/main/webapp/script/demo.js
@@ -120,15 +120,3 @@ Demo.initGoogleSearch = function () {
 
 Tobago.registerListener(Demo.initGoogleSearch, Tobago.Phase.DOCUMENT_READY);
 Tobago.registerListener(Demo.initGoogleSearch, Tobago.Phase.AFTER_UPDATE);
-
-Demo.initMailTo = function () {
-  var $command = jQuery("[href^=mailto]");
-  $command.each(function() {
-    var $this = jQuery(this);
-    // this is, to fix URL encoded spaces
-    $this.attr("href", $this.attr("href").replace(/\+/g, "%20"));
-  });
-};
-
-Tobago.registerListener(Demo.initMailTo, Tobago.Phase.DOCUMENT_READY);
-Tobago.registerListener(Demo.initMailTo, Tobago.Phase.AFTER_UPDATE);


### PR DESCRIPTION
…pe spaces

* replace for "name" and "value": "+" (was space) to %20 (means also space)
* UnitTest
* close buttons
* remove workaround from demo.js
* Required parameters for tc:operation