### PR TITLE
fix: unwanted margin on button icon

### DIFF
--- a/tobago-core/src/main/resources/scss/_tobago.scss
+++ b/tobago-core/src/main/resources/scss/_tobago.scss
@@ -235,7 +235,7 @@ tobago-date input {
 }
 
 /* for pickers with more than one icon, e.g. date-time picker */
-.btn > .fa:nth-child(n+2) {
+.btn.datepickerbutton > .fa:nth-child(n+2) {
   margin-left: .3em;
 }
 


### PR DESCRIPTION
The style for the datepickerbutton was applied to all buttons with an icon. Now the style only affects the datepicker button