### PR TITLE
fix: aria-labelledby for dropdown menus

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/CommandRendererBase.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/CommandRendererBase.java
@@ -173,7 +173,7 @@ public abstract class CommandRendererBase extends DecodingCommandRendererBase {
       writer.writeClassAttribute(
           BootstrapClass.DROPDOWN_MENU,
           getDropdownCssItems(facesContext, command));
-      writer.writeAttribute(Arias.LABELLEDBY, "dropdownMenuButton", false);
+      writer.writeAttribute(Arias.LABELLEDBY, command.getFieldId(facesContext), false);
       writer.writeAttribute(HtmlAttributes.NAME, command.getClientId(facesContext), false);
 
       for (final UIComponent child : component.getChildren()) {


### PR DESCRIPTION
The aria-labelledby attribute for dropdown menus has now the ID of the button which opens the dropdown menu.