### PR TITLE
fix: aria-labelledby for dropdown menus

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/CommandRendererBase.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/CommandRendererBase.java
@@ -167,7 +167,7 @@ public abstract class CommandRendererBase extends DecodingCommandRendererBase {
       writer.writeClassAttribute(
           BootstrapClass.DROPDOWN_MENU,
           getDropdownCssItems(facesContext, command));
-      writer.writeAttribute(Arias.LABELLEDBY, "dropdownMenuButton", false);
+      writer.writeAttribute(Arias.LABELLEDBY, command.getFieldId(facesContext), false);
 
       for (final UIComponent child : component.getChildren()) {
         if (child.isRendered()


### PR DESCRIPTION
The aria-labelledby attribute for dropdown menus has now the ID of the button which opens the dropdown menu.

(cherry picked from commit 3ef846273a594ce72cab8e73eafdc16c22b6fe07)