### PR TITLE
fix splitter in Split Layout

### DIFF
--- a/tobago-core/src/main/resources/scss/_tobago.scss
+++ b/tobago-core/src/main/resources/scss/_tobago.scss
@@ -144,6 +144,10 @@ tobago-bar {
   }
 }
 
+tobago-behavior {
+  display: none;
+}
+
 /* box -------------------------------------------------------------- */
 
 .tobago-box {

--- a/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-split-layout.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-split-layout.ts
@@ -32,7 +32,7 @@ class SplitLayout extends HTMLElement {
         justAdded = false;
         continue;
       }
-      if (child.matches("input[type=hidden]")) {
+      if (getComputedStyle(child).display === "none") {
         continue;
       }
       if (first) { // the first needs no splitter handle


### PR DESCRIPTION
* this is a general solution to avoid double splitters
* this solution applies to input, style and tobago-behavior. This Elements have the display: none attribute
* add tobago-behavior to _tobago.scss with display: none