### PR TITLE
fix: dynamic IDs in tc:label 'for' attribute

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUILabel.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUILabel.java
@@ -21,9 +21,25 @@ package org.apache.myfaces.tobago.internal.component;
 
 import org.apache.myfaces.tobago.component.SupportsAccessKey;
 
+import javax.el.ValueExpression;
+
 /**
  * {@link org.apache.myfaces.tobago.internal.taglib.component.LabelTagDeclaration}
  */
 public abstract class AbstractUILabel
     extends AbstractUILabelBase implements SupportsAccessKey {
+
+  /*
+   * Need to set the name to 'forComponent' which comes from UILabel.PropertyKeys.forComponent.
+   * TODO a better way would be to improve the UILabel.PropertyKeys, so an exact string could be specified.
+   * As an example, look at: javax.faces.component.UIMessages
+   */
+  @Override
+  public void setValueExpression(String name, ValueExpression expression) {
+    if ("for".equals(name)) {
+      super.setValueExpression("forComponent", expression);
+    } else {
+      super.setValueExpression(name, expression);
+    }
+  }
 }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/declaration/HasFor.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/declaration/HasFor.java
@@ -19,7 +19,6 @@
 
 package org.apache.myfaces.tobago.internal.taglib.declaration;
 
-import org.apache.myfaces.tobago.apt.annotation.DynamicExpression;
 import org.apache.myfaces.tobago.apt.annotation.TagAttribute;
 import org.apache.myfaces.tobago.apt.annotation.UIComponentTagAttribute;
 
@@ -27,7 +26,7 @@ public interface HasFor {
   /**
    * Id of the component, this is related to.
    */
-  @TagAttribute
-  @UIComponentTagAttribute(expression = DynamicExpression.PROHIBITED)
+  @TagAttribute(rtexprvalue = true)
+  @UIComponentTagAttribute(type = "java.lang.String")
   void setFor(String forComponent);
 }

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/40-test/1500-output/21-label-for/Label_For.test.js
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/40-test/1500-output/21-label-for/Label_For.test.js
@@ -32,6 +32,8 @@ it("Test for required CSS class", function (done) {
   let selectManyListboxLabel = querySelectorFn("#page\\:mainForm\\:selectManyListboxLabel");
   let selectManyShuttleLabel = querySelectorFn("#page\\:mainForm\\:selectManyShuttleLabel");
   let starsLabel = querySelectorFn("#page\\:mainForm\\:starsLabel");
+  let labelForIdOne = querySelectorFn("#page\\:mainForm\\:labelForIdOne");
+  let labelForIdTwo = querySelectorFn("#page\\:mainForm\\:labelForIdTwo");
 
   let test = new JasmineTestTool(done);
   test.do(() => expect(inLabel().classList.contains("tobago-required")).toBe(true));
@@ -47,5 +49,7 @@ it("Test for required CSS class", function (done) {
   test.do(() => expect(selectManyListboxLabel().classList.contains("tobago-required")).toBe(true));
   test.do(() => expect(selectManyShuttleLabel().classList.contains("tobago-required")).toBe(true));
   test.do(() => expect(starsLabel().classList.contains("tobago-required")).toBe(true));
+  test.do(() => expect(labelForIdOne().getAttribute("for")).toEqual("page:mainForm:id1::field"));
+  test.do(() => expect(labelForIdTwo().getAttribute("for")).toEqual("page:mainForm:id2::field"));
   test.start();
 });

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/40-test/1500-output/21-label-for/Label_For.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/40-test/1500-output/21-label-for/Label_For.xhtml
@@ -18,6 +18,7 @@
 -->
 
 <ui:composition template="/main.xhtml"
+                xmlns:c="http://java.sun.com/jsp/jstl/core"
                 xmlns:tc="http://myfaces.apache.org/tobago/component"
                 xmlns:ui="http://java.sun.com/jsf/facelets">
   <ui:param name="title" value="Label 'for'-attribute"/>
@@ -81,4 +82,16 @@
     <tc:label id="starsLabel" for="stars" value="Stars"/>
     <tc:stars id="stars" required="true"/>
   </tc:segmentLayout>
+
+  <tc:section label="ID as value expression">
+    <c:set var="idOne" value="id1"/>
+    <tc:label id="labelForIdOne" value="Label for id '#{idOne}'" for="#{idOne}"/>
+    <tc:in id="#{idOne}" required="true"/>
+
+    <c:set var="idTwo" value="id2"/>
+    <tc:segmentLayout medium="6seg 6seg">
+      <tc:label id="labelForIdTwo" value="Label for id '#{idTwo}'" for="#{idTwo}"/>
+      <tc:in id="#{idTwo}" required="true"/>
+    </tc:segmentLayout>
+  </tc:section>
 </ui:composition>


### PR DESCRIPTION
The 'for' attribute was not able to handle value expressions correctly.
The current fix is more like a workaround. A better way to fix this would be to improve the generated UILabel class, so PropertyKeys enum retuns a string named 'for' instead of 'forComponent'.

Added a test.

Issue: TOBAGO-2037