### PR TITLE
fix: dynamic IDs in tc:label 'for' attribute

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUILabel.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUILabel.java
@@ -21,9 +21,25 @@ package org.apache.myfaces.tobago.internal.component;
 
 import org.apache.myfaces.tobago.component.SupportsAccessKey;
 
+import javax.el.ValueExpression;
+
 /**
  * {@link org.apache.myfaces.tobago.internal.taglib.component.LabelTagDeclaration}
  */
 public abstract class AbstractUILabel
     extends AbstractUILabelBase implements SupportsAccessKey {
+
+  /*
+   * Need to set the name to 'forComponent' which comes from UILabel.PropertyKeys.forComponent.
+   * TODO a better way would be to improve the UILabel.PropertyKeys, so an exact string could be specified.
+   * As an example, look at: javax.faces.component.UIMessages
+   */
+  @Override
+  public void setValueExpression(String name, ValueExpression expression) {
+    if ("for".equals(name)) {
+      super.setValueExpression("forComponent", expression);
+    } else {
+      super.setValueExpression(name, expression);
+    }
+  }
 }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/declaration/HasFor.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/declaration/HasFor.java
@@ -19,7 +19,6 @@
 
 package org.apache.myfaces.tobago.internal.taglib.declaration;
 
-import org.apache.myfaces.tobago.apt.annotation.DynamicExpression;
 import org.apache.myfaces.tobago.apt.annotation.TagAttribute;
 import org.apache.myfaces.tobago.apt.annotation.UIComponentTagAttribute;
 
@@ -27,7 +26,7 @@ public interface HasFor {
   /**
    * Id of the component, this is related to.
    */
-  @TagAttribute
-  @UIComponentTagAttribute(expression = DynamicExpression.PROHIBITED)
+  @TagAttribute(rtexprvalue = true)
+  @UIComponentTagAttribute(type = "java.lang.String")
   void setFor(String forComponent);
 }

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/40-test/1500-output/21-label-for/label-for.test.js
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/40-test/1500-output/21-label-for/label-for.test.js
@@ -16,7 +16,7 @@
  */
 
 QUnit.test("Test for required CSS class", function (assert) {
-  assert.expect(13);
+  assert.expect(15);
 
   var $inLabel = jQueryFrame("#page\\:mainForm\\:inLabel");
   var $dateLabel = jQueryFrame("#page\\:mainForm\\:dateLabel");
@@ -31,6 +31,8 @@ QUnit.test("Test for required CSS class", function (assert) {
   var $selectManyListboxLabel = jQueryFrame("#page\\:mainForm\\:selectManyListboxLabel");
   var $selectManyShuttleLabel = jQueryFrame("#page\\:mainForm\\:selectManyShuttleLabel");
   var $starsLabel = jQueryFrame("#page\\:mainForm\\:starsLabel");
+  var $labelForIdOne = jQueryFrame("#page\\:mainForm\\:labelForIdOne");
+  var $labelForIdTwo = jQueryFrame("#page\\:mainForm\\:labelForIdTwo");
 
   assert.ok($inLabel.hasClass("tobago-required"));
   assert.ok($dateLabel.hasClass("tobago-required"));
@@ -45,4 +47,6 @@ QUnit.test("Test for required CSS class", function (assert) {
   assert.ok($selectManyListboxLabel.hasClass("tobago-required"));
   assert.ok($selectManyShuttleLabel.hasClass("tobago-required"));
   assert.ok($starsLabel.hasClass("tobago-required"));
+  assert.equal($labelForIdOne.attr("for"), "page:mainForm:id1::field");
+  assert.equal($labelForIdTwo.attr("for"), "page:mainForm:id2::field");
 });

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/40-test/1500-output/21-label-for/label-for.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/40-test/1500-output/21-label-for/label-for.xhtml
@@ -18,6 +18,7 @@
 -->
 
 <ui:composition template="/main.xhtml"
+                xmlns:c="http://java.sun.com/jsp/jstl/core"
                 xmlns:tc="http://myfaces.apache.org/tobago/component"
                 xmlns:ui="http://java.sun.com/jsf/facelets">
   <ui:param name="title" value="Label 'for'-attribute"/>
@@ -81,4 +82,16 @@
     <tc:label id="starsLabel" for="stars" value="Stars"/>
     <tc:stars id="stars" required="true"/>
   </tc:segmentLayout>
+
+  <tc:section label="ID as value expression">
+    <c:set var="idOne" value="id1"/>
+    <tc:label id="labelForIdOne" value="Label for id '#{idOne}'" for="#{idOne}"/>
+    <tc:in id="#{idOne}" required="true"/>
+
+    <c:set var="idTwo" value="id2"/>
+    <tc:segmentLayout medium="6seg 6seg">
+      <tc:label id="labelForIdTwo" value="Label for id '#{idTwo}'" for="#{idTwo}"/>
+      <tc:in id="#{idTwo}" required="true"/>
+    </tc:segmentLayout>
+  </tc:section>
 </ui:composition>


### PR DESCRIPTION
The 'for' attribute was not able to handle value expressions correctly.
The current fix is more like a workaround. A better way to fix this would be to improve the generated UILabel class, so PropertyKeys enum retuns a string named 'for' instead of 'forComponent'.

Added a test.

Issue: TOBAGO-2037

(cherry picked from commit 45f72955f07fb4f08cb82df86e8bad8dbd4cd6e1)