### PR TITLE
npm css/ts compiling for development

### DIFF
--- a/tobago-example/tobago-example-demo/pom.xml
+++ b/tobago-example/tobago-example-demo/pom.xml
@@ -37,6 +37,7 @@
     <exec.version>1.6.0</exec.version>
     <finalName>tobago-example-demo</finalName>
     <hibernate-validator.version>4.3.2.Final</hibernate-validator.version>
+    <tobago-theme-standard-dir>${basedir}/target/tobago-theme-standard</tobago-theme-standard-dir>
   </properties>
 
   <build>
@@ -106,6 +107,22 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <configuration>
+              <target>
+                <mkdir dir="${tobago-theme-standard-dir}/META-INF/resources"/>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
         <configuration>
@@ -128,6 +145,9 @@
               <contextPath>/example</contextPath>
             </webApp>
           -->
+          <webApp>
+            <resourceBases>${basedir}/src/main/webapp,${tobago-theme-standard-dir}/META-INF/resources</resourceBases>
+          </webApp>
         </configuration>
         <dependencies>
         </dependencies>
@@ -241,6 +261,36 @@
   </dependencies>
 
   <profiles>
+    <profile>
+      <id>dev</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack-tobago-theme-standard</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${tobago-theme-standard-dir}</outputDirectory>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.apache.myfaces.tobago</groupId>
+                      <artifactId>tobago-theme-standard</artifactId>
+                      <version>${project.version}</version>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
 
     <profile>
       <id>jsf-provided</id>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/10-intro/10-getting-started/Getting_Started.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/10-intro/10-getting-started/Getting_Started.xhtml
@@ -105,4 +105,11 @@ $ mvn jetty:run -Djsf=mojarra-2.3</code></pre>
 
   </tc:section>
 
+  <tc:section label="Development">
+    <p>For development the example-demo could be run with maven profile "dev".</p>
+    <pre><code class="language-bash">$ mvn -Pdev jetty:run</code></pre>
+    <p>In this case the npm scripts "dev-css" and "dev-ts" could be run to compile css and typescript classes.
+      These changes would be detected by jetty without restart.</p>
+  </tc:section>
+
 </ui:composition>

--- a/tobago-theme/tobago-theme-standard/src/main/npm/dev-rollup.config.js
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/dev-rollup.config.js
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import resolve from "rollup-plugin-node-resolve"
+
+export default {
+  input: '../../../target/dist/js/tobago-all.js',
+  output: {
+    file: '../../../target/dist/js/tobago-bundle.js',
+    format: 'umd', /* tbd: check if "iife" is better? */
+    sourcemap: true,
+    name: 'tobago'
+  },
+  plugins: [
+    resolve()
+  ]
+};

--- a/tobago-theme/tobago-theme-standard/src/main/npm/dev-tsconfig.json
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/dev-tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "es6",
+    "target": "ES2015",
+    "noImplicitAny": false,
+    "rootDir": "ts",
+    "outDir": "../../../target/dist/js",
+    "sourceMap": true,
+    "removeComments": false,
+    "noEmitOnError": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true
+  },
+  "include": [
+    "ts/*.ts"
+  ],
+  "exclude": [
+    "ts/*.test.ts",
+    "node_modules",
+    "node"
+  ],
+  "_comment for moduleResolution": "this is to fix a compiler problem with @babel/types, see: https://github.com/microsoft/TypeScript/issues/11103"
+}

--- a/tobago-theme/tobago-theme-standard/src/main/npm/package.json
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/package.json
@@ -28,7 +28,15 @@
     "ts-compile": "tsc",
     "js-minify": "uglifyjs --compress typeofs=false,drop_console=true --mangle --source-map includeSources --output js/tobago.min.js js/tobago-deltaspike.js js/tobago-polyfill.js js/tobago-listener.js js/tobago-core.js js/tobago-dropdown.js js/tobago-date.js js/tobago-command.js js/tobago-file.js js/tobago-focus.js js/tobago-header-footer.js js/tobago-in.js js/tobago-jsf.js js/tobago-overlay.js js/tobago-panel.js js/tobago-popover.js js/tobago-popup.js js/tobago-reload.js js/tobago-scroll.js js/tobago-select-boolean-checkbox.js js/tobago-select-boolean-toggle.js js/tobago-select-many-checkbox.js js/tobago-select-many-shuttle.js js/tobago-select-one-listbox.js js/tobago-select-one-radio.js js/tobago-sheet.js js/tobago-split-layout.js js/tobago-stars.js js/tobago-suggest.js js/tobago-tab.js js/tobago-tree.js js/tobago-tree-listbox.js js/tobago-utils.js",
     "rollup": "rollup --config",
-    "test": "jest"
+    "test": "jest",
+    "dev-css": "npm-run-all --sequential dev-css-compile dev-mkdir dev-css-cp",
+    "dev-css-compile": "node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 --include-path ../../../../../tobago-core/src/main/resources ../scss/tobago-theme.scss ../../../target/dist/css/tobago.css",
+    "dev-css-cp": "cp -R ../../../target/dist/css ../../../../../tobago-example/tobago-example-demo/target/tobago-theme-standard/META-INF/resources/tobago/standard/tobago-bootstrap/$npm_package_version",
+    "dev-ts": "npm-run-all --sequential dev-ts-compile dev-ts-compile-bundle dev-mkdir dev-js-cp",
+    "dev-ts-compile": "tsc --project dev-tsconfig.json",
+    "dev-ts-compile-bundle": "rollup --config dev-rollup.config.js",
+    "dev-js-cp": "cp -R ../../../target/dist/js ../../../../../tobago-example/tobago-example-demo/target/tobago-theme-standard/META-INF/resources/tobago/standard/tobago-bootstrap/$npm_package_version",
+    "dev-mkdir": "mkdir -p ../../../../../tobago-example/tobago-example-demo/target/tobago-theme-standard/META-INF/resources/tobago/standard/tobago-bootstrap/$npm_package_version"
   },
   "dependencies": {
     "@vaadin/vaadin-combo-box": "^5.0.9",


### PR DESCRIPTION
In the tobago-example-demo, jetty is now looking for static resources in two directories: The default "webapp" directory and a "target/tobago-standard-theme"-directory which may contain the tobago-standard-theme resources. Both directories must be exist, otherwise jetty won't start.
If Jetty is started with maven profile "dev", the tobago-standard-theme will be unpacked in the "target/tobago-standard-theme"-directory. In this case Jetty would detect chances to CSS/JS files without restart.
The npm scripts "dev-css" and "dev-ts" are added to the tobago-standard-theme package.json and can be used to compile and copy css/ts files to the "target/tobago-standard-theme"-directory.