### PR TITLE
set aria roles for header and footer

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/FooterRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/FooterRenderer.java
@@ -27,6 +27,7 @@ import org.apache.myfaces.tobago.renderkit.css.BootstrapClass;
 import org.apache.myfaces.tobago.renderkit.css.TobagoClass;
 import org.apache.myfaces.tobago.renderkit.html.HtmlAttributes;
 import org.apache.myfaces.tobago.renderkit.html.HtmlElements;
+import org.apache.myfaces.tobago.renderkit.html.HtmlRoleValues;
 import org.apache.myfaces.tobago.webapp.TobagoResponseWriter;
 
 import javax.faces.component.UIComponent;
@@ -48,6 +49,7 @@ public class FooterRenderer extends RendererBase {
         TobagoClass.FOOTER.createMarkup(markup),
         footer.isFixed() ? BootstrapClass.FIXED_BOTTOM : null,
         footer.getCustomClass());
+    writer.writeAttribute(HtmlAttributes.ROLE, HtmlRoleValues.CONTENTINFO.toString(), false);
     writer.writeAttribute(HtmlAttributes.TITLE, footer.getTip(), true);
     HtmlRendererUtils.writeDataAttributes(facesContext, writer, footer);
   }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/HeaderRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/HeaderRenderer.java
@@ -27,6 +27,7 @@ import org.apache.myfaces.tobago.renderkit.css.BootstrapClass;
 import org.apache.myfaces.tobago.renderkit.css.TobagoClass;
 import org.apache.myfaces.tobago.renderkit.html.HtmlAttributes;
 import org.apache.myfaces.tobago.renderkit.html.HtmlElements;
+import org.apache.myfaces.tobago.renderkit.html.HtmlRoleValues;
 import org.apache.myfaces.tobago.webapp.TobagoResponseWriter;
 
 import javax.faces.component.UIComponent;
@@ -51,6 +52,7 @@ public class HeaderRenderer extends RendererBase {
         header.isFixed() ? BootstrapClass.STICKY_TOP : null,
         header.getCustomClass());
 // TBD: should NAVBAR class be in the LinksRenderer?
+    writer.writeAttribute(HtmlAttributes.ROLE, HtmlRoleValues.BANNER.toString(), false);
     writer.writeAttribute(HtmlAttributes.TITLE, header.getTip(), true);
     HtmlRendererUtils.writeDataAttributes(facesContext, writer, header);
   }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/renderkit/html/HtmlRoleValues.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/renderkit/html/HtmlRoleValues.java
@@ -22,6 +22,8 @@ package org.apache.myfaces.tobago.renderkit.html;
 public enum HtmlRoleValues {
 
   ALERT("alert"),
+  BANNER("banner"),
+  CONTENTINFO("contentinfo"),
   DIALOG("dialog"),
   DOCUMENT("document"),
   GROUP("group"),


### PR DESCRIPTION
<header> was replaced with <tobago-header>. To keep the 'meaning', the role 'bannar' is now set for <tobago-header>.
<footer> was replaceed with <tobago-footer>. To keep the 'meaning', the role 'contentinfo' is now set for <tobago-footer>