### PR TITLE
remove "d-flex" css class

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/FlexLayoutRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/FlexLayoutRenderer.java
@@ -44,7 +44,6 @@ public class FlexLayoutRenderer extends RendererBase {
     writer.writeClassAttribute(
         TobagoClass.FLEX_LAYOUT,
         TobagoClass.FLEX_LAYOUT.createMarkup(markup),
-        BootstrapClass.D_FLEX,
         flexLayout.isHorizontal() ? BootstrapClass.FLEX_ROW : BootstrapClass.FLEX_COLUMN,
         BootstrapClass.valueOf(flexLayout.getAlignItems()),
         markup != null && markup.contains(Markup.SPREAD) ? TobagoClass.SPREAD : null);

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/LabelLayoutRendererBase.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/LabelLayoutRendererBase.java
@@ -137,7 +137,6 @@ public abstract class LabelLayoutRendererBase extends DecodingInputRendererBase 
     }
     writer.writeClassAttribute(
         flex ? TobagoClass.FLEX_LAYOUT : null,
-        flex ? BootstrapClass.D_FLEX : null,
         BootstrapClass.FORM_GROUP,
         TobagoClass.LABEL__CONTAINER,
         ComponentUtils.getBooleanAttribute(component, Attributes.required) ? TobagoClass.REQUIRED : null,

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/MessageLayoutRendererBase.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/MessageLayoutRendererBase.java
@@ -84,7 +84,7 @@ public abstract class MessageLayoutRendererBase extends LabelLayoutRendererBase 
 
     if (hasMessage || hasHelp) {
       writer.startElement(HtmlElements.DIV);
-      writer.writeClassAttribute(TobagoClass.MESSAGES__CONTAINER, TobagoClass.FLEX_LAYOUT, BootstrapClass.D_FLEX);
+      writer.writeClassAttribute(TobagoClass.MESSAGES__CONTAINER, TobagoClass.FLEX_LAYOUT);
     }
   }
 

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SplitLayoutRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SplitLayoutRenderer.java
@@ -75,7 +75,6 @@ public class SplitLayoutRenderer extends RendererBase {
     writer.startElement(HtmlElements.TOBAGO_SPLIT_LAYOUT);
     writer.writeIdAttribute(splitLayout.getClientId(facesContext));
     writer.writeClassAttribute(
-        BootstrapClass.D_FLEX,
         splitLayout.isHorizontal() ? BootstrapClass.FLEX_ROW : BootstrapClass.FLEX_COLUMN,
         markup != null && markup.contains(Markup.SPREAD) ? TobagoClass.SPREAD : null);
     writer.writeAttribute(CustomAttributes.ORIENTATION,

--- a/tobago-core/src/main/resources/scss/_tobago.scss
+++ b/tobago-core/src/main/resources/scss/_tobago.scss
@@ -285,6 +285,7 @@ tobago-file {
 /* flexLayout -------------------------------------------------------------- */
 
 .tobago-flexLayout {
+  display: flex;
   min-width: 0;
   /* without this, Firefox/Webkit are different from IE:
      Set the minimal width to zero make flex-layout responsive for the width,
@@ -1366,6 +1367,7 @@ tobago-sheet {
 
 /* splitLayout ---------------------------------------------------------------------- */
 tobago-split-layout {
+  display: flex;
 }
 
 .tobago-splitLayout {


### PR DESCRIPTION
We should avoid the usage of "d-flex" CSS class from Bootstrap, because it uses the "!important". In this case the "!important" keyword only prevent custom styling but has no advantage.
A better way is to set the "display: flex" (without ""!important") style on the tobago CSS class.