### PR TITLE
fix rollup resolve plugin configuration

### DIFF
--- a/tobago-theme/tobago-theme-standard/src/main/npm/dev-rollup.config.js
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/dev-rollup.config.js
@@ -26,6 +26,10 @@ export default {
     name: 'tobago'
   },
   plugins: [
-    resolve()
+    resolve({
+      customResolveOptions: {
+        moduleDirectory: 'src/main/npm/node_modules'
+      }
+    })
   ]
 };


### PR DESCRIPTION
By default, the rollup resolve plugin is searching for the 'node_modules' directory in all parent directories.