### PR TITLE
check getRootNode() usage

### DIFF
--- a/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-bar.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-bar.ts
@@ -71,13 +71,11 @@ class Bar extends HTMLElement {
   }
 
   private get toggleButton(): HTMLButtonElement {
-    const root = this.getRootNode() as ShadowRoot | Document;
-    return root.querySelector(".navbar-toggler");
+    return this.querySelector(".navbar-toggler");
   }
 
   private get navbarContent(): HTMLDivElement {
-    const root = this.getRootNode() as ShadowRoot | Document;
-    return root.querySelector(".navbar-collapse");
+    return this.querySelector(".navbar-collapse");
   }
 }
 

--- a/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-messages.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-messages.ts
@@ -32,8 +32,7 @@ class Messages extends HTMLElement {
   }
 
   get closeButtons(): NodeListOf<HTMLButtonElement> {
-    const root = this.getRootNode() as ShadowRoot | Document;
-    return root.querySelectorAll(".alert button.close");
+    return this.querySelectorAll(".alert button.close");
   }
 }
 

--- a/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-select-boolean-checkbox.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-select-boolean-checkbox.ts
@@ -35,8 +35,7 @@ export class SelectBooleanCheckbox extends HTMLElement {
   }
 
   get input(): HTMLInputElement {
-    const rootNode = this.getRootNode() as ShadowRoot | Document;
-    return rootNode.getElementById(this.id + DomUtils.SUB_COMPONENT_SEP + "field") as HTMLInputElement;
+    return this.querySelector(DomUtils.escapeClientId(this.id + DomUtils.SUB_COMPONENT_SEP + "field"));
   }
 }
 

--- a/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-select-boolean-toggle.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-select-boolean-toggle.ts
@@ -15,29 +15,9 @@
  * limitations under the License.
  */
 
-import {DomUtils} from "./tobago-utils";
+import {SelectBooleanCheckbox} from "./tobago-select-boolean-checkbox";
 
-class SelectBooleanToggle extends HTMLElement {
-
-  constructor() {
-    super();
-  }
-
-  connectedCallback(): void {
-    if (this.input.readOnly) {
-      this.input.addEventListener("click", preventClick);
-    }
-
-    function preventClick(event: MouseEvent): void {
-      // in the "readonly" case, prevent the default, which is changing the "checked" state
-      event.preventDefault();
-    }
-  }
-
-  get input(): HTMLInputElement {
-    const rootNode = this.getRootNode() as ShadowRoot | Document;
-    return rootNode.getElementById(this.id + DomUtils.SUB_COMPONENT_SEP + "field") as HTMLInputElement;
-  }
+class SelectBooleanToggle extends SelectBooleanCheckbox {
 }
 
 document.addEventListener("DOMContentLoaded", function (event: Event): void {

--- a/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-select-many-checkbox.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/npm/ts/tobago-select-many-checkbox.ts
@@ -30,14 +30,12 @@ class SelectManyCheckbox extends HTMLElement {
       function preventClick(event: MouseEvent): void {
         // in the "readonly" case, prevent the default, which is changing the "checked" state
         event.preventDefault();
-        console.log("slectmanycheckbox bubb.");
       }
     }
   }
 
   get inputs(): NodeListOf<HTMLInputElement> {
-    const rootNode = this.getRootNode() as ShadowRoot | Document;
-    return rootNode.querySelectorAll("input[name='" + this.id + "']");
+    return this.querySelectorAll("input[name='" + this.id + "']");
   }
 }
 


### PR DESCRIPTION
There are some unnecessary usage of getRootNode(). Now 'this' is used instead.
In the case of tobago-select-boolean-toggle we can just extends "SelectBooleanCheckbox".