### PR TITLE
rearrange demo layout

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/NavigationState.java
+++ b/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/NavigationState.java
@@ -19,7 +19,6 @@
 
 package org.apache.myfaces.tobago.example.demo;
 
-import org.apache.deltaspike.core.api.scope.WindowScoped;
 import org.apache.myfaces.tobago.model.ExpandedState;
 import org.apache.myfaces.tobago.model.SelectedState;
 import org.apache.myfaces.tobago.model.TreePath;
@@ -28,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
+import javax.enterprise.context.SessionScoped;
 import javax.enterprise.event.Observes;
 import javax.faces.context.FacesContext;
 import javax.inject.Inject;
@@ -35,7 +35,7 @@ import javax.inject.Named;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 
-@WindowScoped
+@SessionScoped
 @Named
 public class NavigationState implements Serializable {
 
@@ -48,7 +48,7 @@ public class NavigationState implements Serializable {
 
   private TreeState state = new TreeState(new ExpandedState(1), new SelectedState());
 
-  private boolean viewSource = true;
+  private boolean viewSource = false;
 
   @PostConstruct
   public void init() {

--- a/tobago-example/tobago-example-demo/src/main/webapp/main.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/main.xhtml
@@ -19,10 +19,11 @@
 
 <!-- main template for this demo application, you may also use plain.xhtml for test purpose -->
 
-<ui:composition xmlns:f="http://java.sun.com/jsf/core"
-                xmlns:tc="http://myfaces.apache.org/tobago/component"
-                xmlns:ui="http://java.sun.com/jsf/facelets"
-                xmlns="http://www.w3.org/1999/xhtml">
+<ui:composition
+        xmlns:f="http://java.sun.com/jsf/core"
+        xmlns:tc="http://myfaces.apache.org/tobago/component"
+        xmlns:ui="http://java.sun.com/jsf/facelets"
+        xmlns="http://www.w3.org/1999/xhtml">
   <f:view locale="#{localeController.locale}">
     <tc:page label="Tobago Demo - #{navigationState.currentNode.label}" id="page">
       <tc:attribute name="label" value="#{title}" mode="valueIfSet"/>
@@ -43,29 +44,36 @@
 
       <ui:include src="/menu.xhtml"/>
 
-      <tc:segmentLayout extraLarge="auto 1fr 4seg" small="auto 1fr 12seg" extraSmall="12seg">
-        <tc:panel>
-          <tc:style width="250px"/>
-          <ui:include src="/navigation.xhtml"/>
-        </tc:panel>
+      <tc:panel>
+        <tc:style customClass="#{navigationState.viewSource ? '' : 'container mx-auto'}"/>
 
-        <tc:panel>
-          <tc:messages id="messages" orderBy="severity" rendered="#{!hideGlobalMessages}"/>
+        <tc:segmentLayout small="#{navigationState.viewSource ? '2seg 10seg' : 'auto 1fr'}">
+          <tc:panel>
+            <ui:include src="/navigation.xhtml"/>
+          </tc:panel>
 
-          <tc:section label="#{navigationState.currentNode.label}" id="content">
-            <tc:attribute name="label" value="#{title}" mode="valueIfSet"/>
-            <tc:form id="mainForm">
-              <ui:insert/>
-            </tc:form>
-          </tc:section>
-        </tc:panel>
+          <tc:splitLayout columns="1fr">
+            <tc:style display="#{navigationState.viewSource ? '' : 'block'}"/>
+            <tc:panel>
+              <tc:messages id="messages" orderBy="severity" rendered="#{!hideGlobalMessages}"/>
 
-        <tc:panel rendered="#{navigationState.viewSource}">
-          <pre><code class="language-markup" id="demo-view-source">
-            <tc:out keepLineBreaks="false" value="#{navigationTree.source}"/>
-          </code></pre>
-        </tc:panel>
-      </tc:segmentLayout>
+              <tc:section label="#{navigationState.currentNode.label}" id="content">
+                <tc:attribute name="label" value="#{title}" mode="valueIfSet"/>
+                <tc:form id="mainForm">
+                  <ui:insert/>
+                </tc:form>
+              </tc:section>
+            </tc:panel>
+
+            <tc:panel rendered="#{navigationState.viewSource}">
+              <tc:style overflowY="auto"/>
+              <pre><code class="language-markup" id="demo-view-source">
+              <tc:out keepLineBreaks="false" value="#{navigationTree.source}"/>
+            </code></pre>
+            </tc:panel>
+          </tc:splitLayout>
+        </tc:segmentLayout>
+      </tc:panel>
 
       <tc:popup id="info" collapsedMode="hidden">
         <tc:box label="Client Information">
@@ -85,7 +93,7 @@
 
       <tc:footer fixed="true">
         © 2005-2020 Apache Software Foundation, Licensed under the <a
-          href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>.
+              href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>.
       </tc:footer>
 
     </tc:page>


### PR DESCRIPTION
The source code is hidden by default. If source code is show in a split layout.
The source code is now activated/deactivated for the session, not only the window.