### PR TITLE
Delete nodejs directories with Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -881,23 +881,6 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>3.1.0</version>
-          <configuration>
-            <filesets>
-              <fileset>
-                <directory>npm</directory>
-                <includes>
-                  <include>node/**</include>
-                  <include>node_modules/**</include>
-                </includes>
-                <followSymlinks>false</followSymlinks>
-              </fileset>
-            </filesets>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>3.0.1</version>
         </plugin>
@@ -1196,6 +1179,24 @@
       <id>frontend</id>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+            <version>3.1.0</version>
+            <configuration>
+              <filesets>
+                <fileset>
+                  <directory>npm</directory>
+                  <includes>
+                    <include>dist/**</include>
+                    <include>node/**</include>
+                    <include>node_modules/**</include>
+                  </includes>
+                  <followSymlinks>false</followSymlinks>
+                </fileset>
+              </filesets>
+            </configuration>
+          </plugin>
           <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>


### PR DESCRIPTION
* The nodejs directories are deleted with 'mvn clean -Pfrontend'
* nodejs directories are: dist, node, node_modules