### PR TITLE
docs: add contributing info and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,24 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Code of Conduct
+
+* [Code of Conduct for The Apache Software Foundation][1]
+
+[1]: https://www.apache.org/foundation/policies/conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,8 @@ Examples
 - fix(select):
 - docs(menu):
 
+The `(<scope>)` field is optional.
+
 ##### Subject
 
 The subject contains a succinct description of the change:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,7 @@
 
 ## Semantic Commit Messages
 
-Inspired by [Git Commit Msg][git-commit-msg] 
-and [Angular Commit Message Format][angular-commit-message-format]
+Inspired by [Git Commit Msg][git-commit-msg], [Angular Commit Message Format][angular-commit-message-format] and [Conventional Commits][conventional-commits]
 
 
 ### <a name="commit-message-format"></a> Commit Message Format
@@ -67,3 +66,5 @@ reference Jira issues that this commit **Closes**, **Fixes**, or **Relates to**.
 [git-commit-msg]: http://karma-runner.github.io/6.1/dev/git-commit-msg.html
 
 [angular-commit-message-format]: https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format
+
+[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ The body should include the motivation for the change and contrast this with pre
 ##### Footer
 
 The footer should contain any information about **Breaking Changes** and is also the place to
-reference Jira issues that this commit **Closes**, **Fixes**, or **Relates to**.
+reference Jira issues that this commit **Issue: TOBAGO-XXXX**.
 
 [git-commit-msg]: http://karma-runner.github.io/6.1/dev/git-commit-msg.html
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# (WIP) Contributing Info 
+
+## Semantic Commit Messages
+
+Inspired by [Git Commit Msg][git-commit-msg] 
+and [Angular Commit Message Format][angular-commit-message-format]
+
+
+### <a name="commit-message-format"></a> Commit Message Format
+
+Each commit message consists of a **header**, a **body** and a **footer**. The header has a special
+format that includes a **type**, a **scope**, and a **subject**:
+
+```html
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+> Any line of the commit message cannot be longer 100 characters!<br/>
+This allows the message to be easier to read on GitHub as well as in various Git tools.
+
+##### Type
+
+Must be one of the following:
+
+* **feat**: A new feature
+* **fix**: A bug fix
+* **docs**: Documentation only changes
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
+  semi-colons, etc)
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **perf**: A code change that improves performance
+* **test**: Adding missing tests
+* **chore**: Changes to the auxiliary tools such as release scripts
+* **build**: Changes to the dependencies, devDependencies, or build tooling
+* **ci**: Changes to our Continuous Integration configuration
+
+##### Scope
+
+The scope could be anything that helps specify the scope (or feature) that is changing.
+
+Examples
+- fix(select):
+- docs(menu):
+
+##### Subject
+
+The subject contains a succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize first letter
+* no period (.) at the end
+
+##### Body
+
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+##### Footer
+
+The footer should contain any information about **Breaking Changes** and is also the place to
+reference Jira issues that this commit **Closes**, **Fixes**, or **Relates to**.
+
+[git-commit-msg]: http://karma-runner.github.io/6.1/dev/git-commit-msg.html
+
+[angular-commit-message-format]: https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format


### PR DESCRIPTION
The contributing info contains a suggestion for a commit message format. Please comment