### PR TITLE
feature(attribute): auto spacing

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/component/Attributes.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/component/Attributes.java
@@ -39,6 +39,7 @@ public enum Attributes {
   alt,
   autocomplete,
   autoReload,
+  autoSpacing,
   backgroundImage,
   bodyContent,
   border,

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/component/SupportsAutoSpacing.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/component/SupportsAutoSpacing.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.myfaces.tobago.component;
+
+import org.apache.myfaces.tobago.renderkit.html.HtmlElements;
+
+import javax.faces.context.FacesContext;
+import java.util.Map;
+
+public interface SupportsAutoSpacing {
+  /**
+   * use {@link #getAutoSpacing(FacesContext)} to get the correct default value.
+   * return null if autoSpacing is not set manually
+   */
+  Boolean getAutoSpacing();
+
+  default boolean getAutoSpacing(final FacesContext facesContext) {
+    Boolean autoSpacing = getAutoSpacing();
+    if (autoSpacing != null) {
+      return autoSpacing;
+    } else {
+      final Map<Object, Object> attributes = facesContext.getAttributes();
+      return attributes.get(HtmlElements.TOBAGO_HEADER) == null
+          && attributes.get(HtmlElements.TOBAGO_FOOTER) == null
+          && attributes.get(HtmlElements.TOBAGO_SHEET) == null
+          && attributes.get(HtmlElements.TOBAGO_LINKS) == null
+          && attributes.get(HtmlElements.TOBAGO_BUTTONS) == null
+          && attributes.get(Facets.before) == null
+          && attributes.get(Facets.after) == null
+          && attributes.get(Facets.label) == null
+          && attributes.get(Facets.bar) == null;
+    }
+  }
+}

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUIBox.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUIBox.java
@@ -19,10 +19,12 @@
 
 package org.apache.myfaces.tobago.internal.component;
 
+import org.apache.myfaces.tobago.component.SupportsAutoSpacing;
+
 /**
  * {@link org.apache.myfaces.tobago.internal.taglib.component.BoxTagDeclaration}
  */
-public abstract class AbstractUIBox extends AbstractUICollapsiblePanel {
+public abstract class AbstractUIBox extends AbstractUICollapsiblePanel implements SupportsAutoSpacing {
 
   public abstract String getLabel();
 }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUICommand.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUICommand.java
@@ -21,6 +21,7 @@ package org.apache.myfaces.tobago.internal.component;
 
 import org.apache.myfaces.tobago.component.SupportFieldId;
 import org.apache.myfaces.tobago.component.SupportsAccessKey;
+import org.apache.myfaces.tobago.component.SupportsAutoSpacing;
 import org.apache.myfaces.tobago.component.Visual;
 import org.apache.myfaces.tobago.util.ComponentUtils;
 
@@ -34,7 +35,7 @@ import javax.faces.context.FacesContext;
  * Base class for commands.
  */
 public abstract class AbstractUICommand extends AbstractUICommandBase
-    implements SupportsAccessKey, Visual, ClientBehaviorHolder, SupportFieldId {
+    implements SupportsAutoSpacing, SupportsAccessKey, Visual, ClientBehaviorHolder, SupportFieldId {
 
   enum PropertyKeys {
     disabled,

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUIFile.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUIFile.java
@@ -20,6 +20,7 @@
 package org.apache.myfaces.tobago.internal.component;
 
 import org.apache.myfaces.tobago.component.SupportFieldId;
+import org.apache.myfaces.tobago.component.SupportsAutoSpacing;
 import org.apache.myfaces.tobago.component.SupportsHelp;
 import org.apache.myfaces.tobago.component.SupportsLabelLayout;
 import org.apache.myfaces.tobago.component.Visual;
@@ -36,7 +37,7 @@ import javax.servlet.http.Part;
  * {@link org.apache.myfaces.tobago.internal.taglib.component.FileTagDeclaration}
  */
 public abstract class AbstractUIFile extends UIInput implements SupportsLabelLayout, Visual, ClientBehaviorHolder,
-    SupportFieldId, SupportsHelp {
+    SupportFieldId, SupportsHelp, SupportsAutoSpacing {
 
   private transient boolean nextToRenderIsLabel;
 

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUIInput.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUIInput.java
@@ -21,6 +21,7 @@ package org.apache.myfaces.tobago.internal.component;
 
 import org.apache.myfaces.tobago.component.SupportFieldId;
 import org.apache.myfaces.tobago.component.SupportsAccessKey;
+import org.apache.myfaces.tobago.component.SupportsAutoSpacing;
 import org.apache.myfaces.tobago.component.SupportsHelp;
 import org.apache.myfaces.tobago.component.SupportsLabelLayout;
 import org.apache.myfaces.tobago.component.Visual;
@@ -33,7 +34,8 @@ import javax.faces.context.FacesContext;
  * Base class for some inputs.
  */
 public abstract class AbstractUIInput extends javax.faces.component.UIInput
-    implements SupportsAccessKey, SupportsLabelLayout, Visual, ClientBehaviorHolder, SupportFieldId, SupportsHelp {
+    implements SupportsAccessKey, SupportsAutoSpacing, SupportsLabelLayout, Visual, ClientBehaviorHolder,
+    SupportFieldId, SupportsHelp {
 
   private transient boolean nextToRenderIsLabel;
 

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUILinks.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUILinks.java
@@ -19,13 +19,14 @@
 
 package org.apache.myfaces.tobago.internal.component;
 
+import org.apache.myfaces.tobago.component.SupportsAutoSpacing;
 import org.apache.myfaces.tobago.component.SupportsDisabled;
 import org.apache.myfaces.tobago.layout.Orientation;
 
 /**
  * {@link org.apache.myfaces.tobago.internal.taglib.component.LinksTagDeclaration}
  */
-public abstract class AbstractUILinks extends AbstractUIPanelBase implements SupportsDisabled {
+public abstract class AbstractUILinks extends AbstractUIPanelBase implements SupportsAutoSpacing, SupportsDisabled {
 
   enum PropertyKeys {
     disabled,

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUIOut.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUIOut.java
@@ -19,6 +19,7 @@
 
 package org.apache.myfaces.tobago.internal.component;
 
+import org.apache.myfaces.tobago.component.SupportsAutoSpacing;
 import org.apache.myfaces.tobago.component.SupportsLabelLayout;
 import org.apache.myfaces.tobago.component.Visual;
 import org.apache.myfaces.tobago.sanitizer.SanitizeMode;
@@ -28,7 +29,7 @@ import javax.faces.component.UIOutput;
 /**
  * {@link org.apache.myfaces.tobago.internal.taglib.component.OutTagDeclaration}
  */
-public abstract class AbstractUIOut extends UIOutput implements SupportsLabelLayout, Visual {
+public abstract class AbstractUIOut extends UIOutput implements SupportsLabelLayout, Visual, SupportsAutoSpacing {
 
   private transient boolean nextToRenderIsLabel;
 

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUISelectBoolean.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUISelectBoolean.java
@@ -22,6 +22,7 @@ package org.apache.myfaces.tobago.internal.component;
 import org.apache.myfaces.tobago.component.LabelLayout;
 import org.apache.myfaces.tobago.component.SupportFieldId;
 import org.apache.myfaces.tobago.component.SupportsAccessKey;
+import org.apache.myfaces.tobago.component.SupportsAutoSpacing;
 import org.apache.myfaces.tobago.component.SupportsHelp;
 import org.apache.myfaces.tobago.component.SupportsLabelLayout;
 import org.apache.myfaces.tobago.component.Visual;
@@ -34,7 +35,8 @@ import javax.faces.component.behavior.ClientBehaviorHolder;
 import javax.faces.context.FacesContext;
 
 public abstract class AbstractUISelectBoolean extends UISelectBoolean
-    implements Visual, ClientBehaviorHolder, SupportFieldId, SupportsAccessKey, SupportsLabelLayout, SupportsHelp {
+    implements SupportsAutoSpacing, Visual, ClientBehaviorHolder, SupportFieldId, SupportsAccessKey,
+    SupportsLabelLayout, SupportsHelp {
 
   private transient boolean nextToRenderIsLabel;
 

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUISelectManyBase.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUISelectManyBase.java
@@ -19,6 +19,7 @@
 
 package org.apache.myfaces.tobago.internal.component;
 
+import org.apache.myfaces.tobago.component.SupportsAutoSpacing;
 import org.apache.myfaces.tobago.component.SupportsHelp;
 import org.apache.myfaces.tobago.component.SupportsLabelLayout;
 import org.apache.myfaces.tobago.component.Visual;
@@ -32,7 +33,7 @@ import java.util.Collection;
  * Base class for multi select.
  */
 public abstract class AbstractUISelectManyBase extends UISelectMany
-    implements Visual, SupportsLabelLayout, ClientBehaviorHolder, SupportsHelp {
+    implements SupportsAutoSpacing, Visual, SupportsLabelLayout, ClientBehaviorHolder, SupportsHelp {
 
   private transient boolean nextToRenderIsLabel;
 

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUISelectOneBase.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUISelectOneBase.java
@@ -19,6 +19,7 @@
 
 package org.apache.myfaces.tobago.internal.component;
 
+import org.apache.myfaces.tobago.component.SupportsAutoSpacing;
 import org.apache.myfaces.tobago.component.SupportsHelp;
 import org.apache.myfaces.tobago.component.SupportsLabelLayout;
 import org.apache.myfaces.tobago.component.Visual;
@@ -32,7 +33,7 @@ import javax.faces.context.FacesContext;
  * Base class for select one.
  */
 public abstract class AbstractUISelectOneBase extends javax.faces.component.UISelectOne
-    implements Visual, SupportsLabelLayout, ClientBehaviorHolder, SupportsHelp {
+    implements SupportsAutoSpacing, Visual, SupportsLabelLayout, ClientBehaviorHolder, SupportsHelp {
 
   public static final String MESSAGE_VALUE_REQUIRED = "org.apache.myfaces.tobago.UISelectOne.REQUIRED";
 

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUITabGroup.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUITabGroup.java
@@ -20,6 +20,7 @@
 package org.apache.myfaces.tobago.internal.component;
 
 import org.apache.myfaces.tobago.component.Attributes;
+import org.apache.myfaces.tobago.component.SupportsAutoSpacing;
 import org.apache.myfaces.tobago.event.TabChangeEvent;
 import org.apache.myfaces.tobago.event.TabChangeListener;
 import org.apache.myfaces.tobago.event.TabChangeSource;
@@ -47,7 +48,7 @@ import java.util.List;
  * {@link org.apache.myfaces.tobago.internal.taglib.component.TabGroupTagDeclaration}
  */
 public abstract class AbstractUITabGroup extends AbstractUIPanelBase
-    implements TabChangeSource, TobagoActionSource, ClientBehaviorHolder {
+    implements TabChangeSource, TobagoActionSource, ClientBehaviorHolder, SupportsAutoSpacing {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/BarRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/BarRenderer.java
@@ -110,7 +110,9 @@ public class BarRenderer<T extends AbstractUIBar> extends RendererBase<T> {
     if (after != null) {
       writer.startElement(HtmlElements.DIV);
       writer.writeClassAttribute(BootstrapClass.MY_LG_0, BootstrapClass.MS_AUTO);
+      insideBegin(facesContext, Facets.after);
       after.encodeAll(facesContext);
+      insideEnd(facesContext, Facets.after);
       writer.endElement(HtmlElements.DIV);
     }
     writer.endElement(HtmlElements.DIV);

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/BoxRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/BoxRenderer.java
@@ -43,11 +43,13 @@ public class BoxRenderer<T extends AbstractUIBox> extends CollapsiblePanelRender
     final TobagoResponseWriter writer = getResponseWriter(facesContext);
     final Markup markup = component.getMarkup();
     final boolean collapsed = component.isCollapsed();
+    final boolean autoSpacing = component.getAutoSpacing(facesContext);
 
     writer.startElement(HtmlElements.TOBAGO_BOX);
     writer.writeClassAttribute(
         BootstrapClass.CARD,
         collapsed ? TobagoClass.COLLAPSED : null,
+        autoSpacing ? TobagoClass.AUTO__SPACING : null,
         component.getCustomClass(),
         markup != null && markup.contains(Markup.SPREAD) ? TobagoClass.SPREAD : null);
     final String clientId = component.getClientId(facesContext);
@@ -71,15 +73,19 @@ public class BoxRenderer<T extends AbstractUIBox> extends CollapsiblePanelRender
 
       writer.startElement(HtmlElements.H3);
       if (labelFacet != null) {
+        insideBegin(facesContext, Facets.label);
         for (final UIComponent child : RenderUtils.getFacetChildren(labelFacet)) {
           child.encodeAll(facesContext);
         }
+        insideEnd(facesContext, Facets.label);
       } else if (labelString != null) {
         writer.writeText(labelString);
       }
       writer.endElement(HtmlElements.H3);
       if (bar != null) {
+        insideBegin(facesContext, Facets.bar);
         bar.encodeAll(facesContext);
+        insideEnd(facesContext, Facets.bar);
       }
 
       writer.endElement(HtmlElements.DIV);

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/ButtonsRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/ButtonsRenderer.java
@@ -41,6 +41,7 @@ public class ButtonsRenderer<T extends AbstractUIButtons> extends RendererBase<T
 
     final Markup markup = component.getMarkup();
     final TobagoResponseWriter writer = getResponseWriter(facesContext);
+    final boolean autoSpacing = component.getAutoSpacing(facesContext);
 
     writer.startElement(HtmlElements.TOBAGO_BUTTONS);
     writer.writeIdAttribute(component.getClientId(facesContext));
@@ -50,6 +51,7 @@ public class ButtonsRenderer<T extends AbstractUIButtons> extends RendererBase<T
         TobagoClass.BUTTONS.createMarkup(markup),
         Orientation.vertical.equals(component.getOrientation())
             ? BootstrapClass.BTN_GROUP_VERTICAL : BootstrapClass.BTN_GROUP,
+        autoSpacing ? TobagoClass.AUTO__SPACING : null,
         component.getCustomClass());
     writer.writeAttribute(HtmlAttributes.ROLE, HtmlRoleValues.GROUP.toString(), false);
     HtmlRendererUtils.writeDataAttributes(facesContext, writer, component);

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/CommandRendererBase.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/CommandRendererBase.java
@@ -68,6 +68,7 @@ public abstract class CommandRendererBase<T extends AbstractUICommand> extends D
     final LabelWithAccessKey label = new LabelWithAccessKey(component);
     final boolean anchor = (component.getLink() != null || component.getOutcome() != null) && !disabled;
     final String target = component.getTarget();
+    final boolean autoSpacing = component.getAutoSpacing(facesContext);
     final boolean parentOfCommands = component.isParentOfCommands();
     final boolean dropdownSubmenu = isInside(facesContext, HtmlElements.COMMAND);
 
@@ -118,6 +119,7 @@ public abstract class CommandRendererBase<T extends AbstractUICommand> extends D
         getRendererCssClass(),
         getRendererCssClass().createMarkup(component.getMarkup()),
         getCssItems(facesContext, component),
+        autoSpacing && !dropdownSubmenu ? TobagoClass.AUTO__SPACING : null,
         dropdownSubmenu ? BootstrapClass.DROPDOWN_ITEM : null,
         parentOfCommands && !dropdownSubmenu ? BootstrapClass.DROPDOWN_TOGGLE : null,
         component.getCustomClass(),

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/FigureRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/FigureRenderer.java
@@ -70,7 +70,9 @@ public class FigureRenderer<T extends AbstractUIFigure> extends RendererBase<T> 
         writer.writeText(labelString);
       }
       if (label != null) {
+        insideBegin(facesContext, Facets.label);
         label.encodeAll(facesContext);
+        insideEnd(facesContext, Facets.label);
       }
       writer.endElement(HtmlElements.FIGCAPTION);
     }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/FooterRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/FooterRenderer.java
@@ -36,6 +36,7 @@ public class FooterRenderer<T extends AbstractUIFooter> extends RendererBase<T> 
   @Override
   public void encodeBeginInternal(final FacesContext facesContext, final T component) throws IOException {
     final TobagoResponseWriter writer = getResponseWriter(facesContext);
+    insideBegin(facesContext, HtmlElements.TOBAGO_FOOTER);
     writer.startElement(HtmlElements.TOBAGO_FOOTER);
     writer.writeIdAttribute(component.getClientId(facesContext));
 
@@ -51,5 +52,6 @@ public class FooterRenderer<T extends AbstractUIFooter> extends RendererBase<T> 
   public void encodeEndInternal(final FacesContext facesContext, final T component) throws IOException {
     final TobagoResponseWriter writer = getResponseWriter(facesContext);
     writer.endElement(HtmlElements.TOBAGO_FOOTER);
+    insideEnd(facesContext, HtmlElements.TOBAGO_FOOTER);
   }
 }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/HeaderRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/HeaderRenderer.java
@@ -36,6 +36,7 @@ public class HeaderRenderer<T extends AbstractUIHeader> extends RendererBase<T> 
   @Override
   public void encodeBeginInternal(final FacesContext facesContext, final T component) throws IOException {
     final TobagoResponseWriter writer = getResponseWriter(facesContext);
+    insideBegin(facesContext, HtmlElements.TOBAGO_HEADER);
     writer.startElement(HtmlElements.TOBAGO_HEADER);
     writer.writeIdAttribute(component.getClientId(facesContext));
     // TBD: NAVBAR_DARK and BG_DARK should not be the default
@@ -54,5 +55,6 @@ public class HeaderRenderer<T extends AbstractUIHeader> extends RendererBase<T> 
   public void encodeEndInternal(final FacesContext facesContext, final T component) throws IOException {
     final TobagoResponseWriter writer = getResponseWriter(facesContext);
     writer.endElement(HtmlElements.TOBAGO_HEADER);
+    insideEnd(facesContext, HtmlElements.TOBAGO_HEADER);
   }
 }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/InRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/InRenderer.java
@@ -176,9 +176,7 @@ public class InRenderer<T extends AbstractUIIn> extends MessageLayoutRendererBas
       final UIComponent addon, final boolean isAfterFacet) throws IOException {
     if (addon != null) {
       for (final UIComponent child : RenderUtils.getFacetChildren(addon)) {
-        if (isAfterFacet) {
-          insideBegin(facesContext, Facets.after);
-        }
+        insideBegin(facesContext, isAfterFacet ? Facets.after : Facets.before);
         if (child instanceof AbstractUIButton) {
           child.encodeAll(facesContext);
         } else if (child instanceof AbstractUIOut) {
@@ -191,9 +189,7 @@ public class InRenderer<T extends AbstractUIIn> extends MessageLayoutRendererBas
           child.encodeAll(facesContext);
           writer.endElement(HtmlElements.SPAN);
         }
-        if (isAfterFacet) {
-          insideEnd(facesContext, Facets.after);
-        }
+        insideEnd(facesContext, isAfterFacet ? Facets.after : Facets.before);
       }
     }
   }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/LabelLayoutRendererBase.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/LabelLayoutRendererBase.java
@@ -22,6 +22,7 @@ package org.apache.myfaces.tobago.internal.renderkit.renderer;
 import org.apache.myfaces.tobago.component.Attributes;
 import org.apache.myfaces.tobago.component.LabelLayout;
 import org.apache.myfaces.tobago.component.SupportsAccessKey;
+import org.apache.myfaces.tobago.component.SupportsAutoSpacing;
 import org.apache.myfaces.tobago.component.SupportsLabelLayout;
 import org.apache.myfaces.tobago.context.Markup;
 import org.apache.myfaces.tobago.internal.component.AbstractUIStyle;
@@ -45,7 +46,7 @@ import java.util.List;
  * Manages the rendering of the <b>label</b> and the <b>field</b> together with different possibilities for the position
  * of the label (defined by {@link org.apache.myfaces.tobago.component.Attributes#labelLayout}
  */
-public abstract class LabelLayoutRendererBase<T extends UIComponent & SupportsLabelLayout>
+public abstract class LabelLayoutRendererBase<T extends UIComponent & SupportsLabelLayout & SupportsAutoSpacing>
     extends DecodingInputRendererBase<T> {
 
   public abstract HtmlElements getComponentTag();
@@ -115,6 +116,7 @@ public abstract class LabelLayoutRendererBase<T extends UIComponent & SupportsLa
     String clientId = component.getClientId(facesContext);
     final Markup markup = (Markup) ComponentUtils.getAttribute(component, Attributes.markup);
 
+    final boolean autoSpacing = component.getAutoSpacing(facesContext);
     final LabelLayout labelLayout = component.getLabelLayout();
     final boolean nextToRenderIsLabel = component.isNextToRenderIsLabel();
     final boolean flex;
@@ -159,7 +161,7 @@ public abstract class LabelLayoutRendererBase<T extends UIComponent & SupportsLa
       writer.writeClassAttribute(
           flex ? TobagoClass.LABEL__CONTAINER : null,
           getComponentCss(facesContext, component),
-          TobagoClass.MARGIN__BOTTOM,
+          autoSpacing ? TobagoClass.AUTO__SPACING : null,
           ComponentUtils.getBooleanAttribute(component, Attributes.required) ? TobagoClass.REQUIRED : null,
           markup != null && markup.contains(Markup.SPREAD) ? TobagoClass.SPREAD : null);
       writeAdditionalAttributes(facesContext, writer, component);

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/LinksRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/LinksRenderer.java
@@ -23,6 +23,7 @@ import org.apache.myfaces.tobago.internal.component.AbstractUILinks;
 import org.apache.myfaces.tobago.layout.Orientation;
 import org.apache.myfaces.tobago.renderkit.RendererBase;
 import org.apache.myfaces.tobago.renderkit.css.BootstrapClass;
+import org.apache.myfaces.tobago.renderkit.css.TobagoClass;
 import org.apache.myfaces.tobago.renderkit.html.HtmlElements;
 import org.apache.myfaces.tobago.webapp.TobagoResponseWriter;
 
@@ -39,11 +40,13 @@ public class LinksRenderer<T extends AbstractUILinks> extends RendererBase<T> {
 //    final boolean insideBar = facesContext.getAttributes().get("inside-bar") != null;
     final boolean insideBar = isInside(facesContext, HtmlElements.TOBAGO_BAR);
     final TobagoResponseWriter writer = getResponseWriter(facesContext);
+    final boolean autoSpacing = component.getAutoSpacing(facesContext);
 
     writer.startElement(HtmlElements.TOBAGO_LINKS);
     writer.writeIdAttribute(component.getClientId(facesContext));
     writer.writeClassAttribute(
         Orientation.vertical.equals(component.getOrientation()) ? BootstrapClass.FLEX_COLUMN : null,
+        autoSpacing ? TobagoClass.AUTO__SPACING : null,
         component.getCustomClass());
     writer.startElement(HtmlElements.UL);
     writer.writeClassAttribute(

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/MessageLayoutRendererBase.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/MessageLayoutRendererBase.java
@@ -19,6 +19,7 @@
 
 package org.apache.myfaces.tobago.internal.renderkit.renderer;
 
+import org.apache.myfaces.tobago.component.SupportsAutoSpacing;
 import org.apache.myfaces.tobago.component.SupportsHelp;
 import org.apache.myfaces.tobago.component.SupportsLabelLayout;
 import org.apache.myfaces.tobago.internal.component.AbstractUIInput;
@@ -41,7 +42,7 @@ import javax.faces.context.FacesContext;
 import java.io.IOException;
 import java.util.List;
 
-public abstract class MessageLayoutRendererBase<T extends UIComponent & SupportsLabelLayout>
+public abstract class MessageLayoutRendererBase<T extends UIComponent & SupportsLabelLayout & SupportsAutoSpacing>
     extends LabelLayoutRendererBase<T> {
 
   @Override

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SectionRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SectionRenderer.java
@@ -86,9 +86,11 @@ public class SectionRenderer<T extends AbstractUISection> extends CollapsiblePan
     final UIComponent labelFacet = ComponentUtils.getFacet(component, Facets.label);
     final String labelString = component.getLabel();
     if (labelFacet != null) {
+      insideBegin(facesContext, Facets.label);
       for (final UIComponent child : RenderUtils.getFacetChildren(labelFacet)) {
         child.encodeAll(facesContext);
       }
+      insideEnd(facesContext, Facets.label);
     } else if (labelString != null) {
       writer.startElement(HtmlElements.SPAN);
       writer.writeText(labelString);
@@ -98,7 +100,9 @@ public class SectionRenderer<T extends AbstractUISection> extends CollapsiblePan
 
     final UIComponent bar = ComponentUtils.getFacet(component, Facets.bar);
     if (bar != null) {
+      insideBegin(facesContext, Facets.bar);
       bar.encodeAll(facesContext);
+      insideEnd(facesContext, Facets.bar);
     }
 
     writer.endElement(HtmlElements.DIV);

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SheetRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SheetRenderer.java
@@ -264,6 +264,7 @@ public class SheetRenderer<T extends AbstractUISheet> extends RendererBase<T> {
     component.init(facesContext);
 
     // Outer sheet div
+    insideBegin(facesContext, HtmlElements.TOBAGO_SHEET);
     writer.startElement(HtmlElements.TOBAGO_SHEET);
     writer.writeIdAttribute(sheetId);
     HtmlRendererUtils.writeDataAttributes(facesContext, writer, component);
@@ -529,6 +530,7 @@ public class SheetRenderer<T extends AbstractUISheet> extends RendererBase<T> {
     if (header.isTransient()) {
       component.getFacets().remove("header");
     }
+    insideEnd(facesContext, HtmlElements.TOBAGO_SHEET);
   }
 
   private void encodeTableBody(

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TabGroupRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TabGroupRenderer.java
@@ -139,6 +139,7 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
     final String hiddenId = clientId + TabGroupRenderer.INDEX_POSTFIX;
     final SwitchType switchType = uiComponent.getSwitchType();
     final Markup markup = uiComponent.getMarkup();
+    final boolean autoSpacing = uiComponent.getAutoSpacing(facesContext);
     final TobagoResponseWriter writer = getResponseWriter(facesContext);
 
     writer.startElement(HtmlElements.TOBAGO_TAB_GROUP);
@@ -146,6 +147,7 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
     writer.writeClassAttribute(
         BootstrapClass.CARD,
         TobagoClass.TAB_GROUP.createMarkup(markup),
+        autoSpacing ? TobagoClass.AUTO__SPACING : null,
         uiComponent.getCustomClass(),
         markup != null && markup.contains(Markup.SPREAD) ? TobagoClass.SPREAD : null);
     HtmlRendererUtils.writeDataAttributes(facesContext, writer, uiComponent);
@@ -296,7 +298,9 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
             labelEmpty = false;
           }
           if (labelFacet != null) {
+            insideBegin(facesContext, Facets.label);
             labelFacet.encodeAll(facesContext);
+            insideEnd(facesContext, Facets.label);
             labelEmpty = false;
           }
           if (labelEmpty) {
@@ -305,9 +309,11 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
           writer.endElement(HtmlElements.A);
 
           if (barFacet != null) {
+            insideBegin(facesContext, Facets.bar);
             writer.startElement(HtmlElements.DIV);
             barFacet.encodeAll(facesContext);
             writer.endElement(HtmlElements.DIV);
+            insideEnd(facesContext, Facets.bar);
           }
 
           writer.endElement(HtmlElements.TOBAGO_TAB);

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/BoxTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/BoxTagDeclaration.java
@@ -29,6 +29,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasCollapsedMode;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasIdBindingAndRendered;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasLabel;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasTip;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsCollapsed;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsVisual;
 
@@ -60,5 +61,5 @@ import javax.faces.component.UIPanel;
     })
 
 public interface BoxTagDeclaration
-    extends HasIdBindingAndRendered, IsVisual, HasLabel, HasTip, IsCollapsed, HasCollapsedMode {
+    extends HasIdBindingAndRendered, IsVisual, HasLabel, HasTip, IsCollapsed, HasCollapsedMode, HasAutoSpacing {
 }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/ButtonTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/ButtonTagDeclaration.java
@@ -41,6 +41,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasOutcome;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasTabIndex;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasTarget;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasTip;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDefaultCommand;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabledBySecurity;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsImmediateCommand;
@@ -132,5 +133,5 @@ public interface ButtonTagDeclaration
     extends HasIdBindingAndRendered, HasAction, HasActionListener, IsImmediateCommand, HasConfirmation,
     HasLink, HasOutcome, HasFragment, IsTransition, HasTarget, IsDisabledBySecurity,
     IsOmit, IsVisual, HasLabel, HasAccessKey, HasTip, HasImage,
-    IsDefaultCommand, HasTabIndex {
+    IsDefaultCommand, HasTabIndex, HasAutoSpacing {
 }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/ButtonsTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/ButtonsTagDeclaration.java
@@ -27,6 +27,7 @@ import org.apache.myfaces.tobago.component.RendererTypes;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasIdBindingAndRendered;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasOrientation;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasTip;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsVisual;
 
 import javax.faces.component.UIPanel;
@@ -46,7 +47,7 @@ import javax.faces.component.UIPanel;
     })
 
 public interface ButtonsTagDeclaration
-    extends HasIdBindingAndRendered, IsVisual, HasTip, HasOrientation {
+    extends HasIdBindingAndRendered, IsVisual, HasTip, HasOrientation, HasAutoSpacing {
 
   /**
    * Flag indicating that this element and all children are disabled.

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/DateTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/DateTagDeclaration.java
@@ -41,6 +41,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidator;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidatorMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValue;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValueChangeListener;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabled;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsFocus;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsReadonly;
@@ -80,7 +81,7 @@ public interface DateTagDeclaration
     extends HasAccessKey, HasValidator, HasValue, HasValueChangeListener, HasTabIndex, IsFocus, IsVisual,
     HasValidatorMessage, HasConverterMessage, HasRequiredMessage, HasIdBindingAndRendered, IsReadonly,
     IsDisabled, HasConverter, HasLabel, HasHelp, HasLabelLayout,
-    HasTip, IsRequired, HasPlaceholder {
+    HasTip, IsRequired, HasPlaceholder, HasAutoSpacing {
 
   /**
    * If true, a today button is displayed on the datetimepicker.

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/FileTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/FileTagDeclaration.java
@@ -39,6 +39,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasTip;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidator;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidatorMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValueChangeListener;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabled;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsFocus;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsMultiple;
@@ -79,7 +80,8 @@ import javax.faces.component.UIInput;
 public interface FileTagDeclaration
     extends HasValidator, HasValidatorMessage, HasRequiredMessage, HasConverterMessage,
     HasValueChangeListener, HasIdBindingAndRendered, IsDisabled, IsFocus, IsMultiple,
-    HasLabel, HasLabelLayout, HasAccessKey, HasTip, HasHelp, IsReadonly, IsRequired, HasTabIndex, IsVisual {
+    HasLabel, HasLabelLayout, HasAccessKey, HasTip, HasHelp, IsReadonly, IsRequired, HasTabIndex, IsVisual,
+    HasAutoSpacing {
 
   /**
    * Value binding expression pointing to a

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/InTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/InTagDeclaration.java
@@ -43,6 +43,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidator;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidatorMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValue;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValueChangeListener;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabled;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsFocus;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsPassword;
@@ -90,6 +91,6 @@ public interface InTagDeclaration
     extends HasIdBindingAndRendered, HasConverter, IsReadonly, IsDisabled, IsRequired, HasHelp, HasTip, IsPassword,
     HasAccessKey, HasValidator, HasValue, HasValueChangeListener, HasTabIndex, IsFocus, IsVisual,
     HasValidatorMessage, HasConverterMessage, HasRequiredMessage, HasLabel, HasLabelLayout,
-    HasAutocomplete, HasPlaceholder {
+    HasAutocomplete, HasPlaceholder, HasAutoSpacing {
 
 }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/LinkTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/LinkTagDeclaration.java
@@ -40,6 +40,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasOutcome;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasTabIndex;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasTarget;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasTip;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabledBySecurity;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsImmediateCommand;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsOmit;
@@ -81,5 +82,5 @@ import javax.faces.component.UICommand;
 public interface LinkTagDeclaration
     extends HasIdBindingAndRendered, HasAction, HasActionListener, IsImmediateCommand, HasConfirmation,
             HasLink, HasOutcome, HasFragment, IsTransition, HasTarget, IsDisabledBySecurity,
-            IsOmit, HasImage, HasTabIndex, IsVisual, HasLabel, HasAccessKey, HasTip {
+            IsOmit, HasImage, HasTabIndex, IsVisual, HasLabel, HasAccessKey, HasTip, HasAutoSpacing {
 }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/LinksTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/LinksTagDeclaration.java
@@ -27,6 +27,7 @@ import org.apache.myfaces.tobago.component.RendererTypes;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasIdBindingAndRendered;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasOrientation;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasTip;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsVisual;
 
 import javax.faces.component.UIPanel;
@@ -44,7 +45,7 @@ import javax.faces.component.UIPanel;
         "javax.faces.component.behavior.ClientBehaviorHolder"
     },
     rendererType = RendererTypes.LINKS)
-public interface LinksTagDeclaration extends HasIdBindingAndRendered, IsVisual, HasTip, HasOrientation {
+public interface LinksTagDeclaration extends HasIdBindingAndRendered, IsVisual, HasTip, HasOrientation, HasAutoSpacing {
 
   /**
    * Flag indicating that this element and all children are disabled.

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/OutTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/OutTagDeclaration.java
@@ -32,6 +32,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasLabelLayout;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasSanitize;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasTip;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValue;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsPlain;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsVisual;
 
@@ -55,7 +56,7 @@ import javax.faces.component.UIOutput;
 
 public interface OutTagDeclaration
     extends HasIdBindingAndRendered, HasConverter, HasTip, HasValue, IsVisual,
-    HasSanitize, HasLabel, HasLabelLayout, IsPlain {
+    HasSanitize, HasLabel, HasLabelLayout, IsPlain, HasAutoSpacing {
 
   /**
    * Flag indicating that characters that are

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/RangeTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/RangeTagDeclaration.java
@@ -28,6 +28,7 @@ import org.apache.myfaces.tobago.apt.annotation.UIComponentTagAttribute;
 import org.apache.myfaces.tobago.component.ClientBehaviors;
 import org.apache.myfaces.tobago.component.RendererTypes;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasAccessKey;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasConverter;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasConverterMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasHelp;
@@ -73,7 +74,7 @@ import javax.faces.component.UIInput;
 public interface RangeTagDeclaration
     extends HasIdBindingAndRendered, HasConverter, IsReadonly, IsDisabled, HasHelp, HasTip,
     HasAccessKey, HasValidator, HasValue, HasValueChangeListener, HasTabIndex, IsFocus, IsVisual,
-    HasValidatorMessage, HasConverterMessage, HasLabel, HasLabelLayout {
+    HasValidatorMessage, HasConverterMessage, HasLabel, HasLabelLayout, HasAutoSpacing {
 
     /**
      * Sets the minimum value of the range.

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectBooleanCheckboxTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectBooleanCheckboxTagDeclaration.java
@@ -41,6 +41,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidator;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidatorMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValue;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValueChangeListener;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabled;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsFocus;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsReadonly;
@@ -78,5 +79,5 @@ public interface SelectBooleanCheckboxTagDeclaration extends HasValidator,
     HasValueChangeListener, HasIdBindingAndRendered, HasValue, IsDisabled,
     HasTip, HasHelp, IsReadonly, HasTabIndex, IsRequiredForSelect, HasConverter, IsFocus,
     HasValidatorMessage, HasRequiredMessageForSelect, HasConverterMessage, IsVisual,
-    HasAccessKey, HasItemLabel, HasItemImage, HasLabel, HasLabelLayout {
+    HasAccessKey, HasItemLabel, HasItemImage, HasLabel, HasLabelLayout, HasAutoSpacing {
 }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectBooleanToggleTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectBooleanToggleTagDeclaration.java
@@ -41,6 +41,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidator;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidatorMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValue;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValueChangeListener;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabled;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsFocus;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsReadonly;
@@ -78,5 +79,5 @@ public interface SelectBooleanToggleTagDeclaration extends HasValidator,
     HasValueChangeListener, HasIdBindingAndRendered, HasValue, IsDisabled,
     HasTip, HasHelp, IsReadonly, HasTabIndex, IsRequiredForSelect, HasConverter, IsFocus,
     HasValidatorMessage, HasRequiredMessageForSelect, HasConverterMessage, IsVisual,
-    HasAccessKey, HasItemLabel, HasItemImage, HasLabel, HasLabelLayout {
+    HasAccessKey, HasItemLabel, HasItemImage, HasLabel, HasLabelLayout, HasAutoSpacing {
 }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectManyCheckboxTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectManyCheckboxTagDeclaration.java
@@ -41,6 +41,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasTip;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidator;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidatorMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValueChangeListener;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabled;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsFocus;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsInline;
@@ -81,7 +82,8 @@ public interface SelectManyCheckboxTagDeclaration extends
     IsDisabled, HasId, HasTip, HasHelp, IsInline, HasRenderRange, IsRendered, IsRequiredForSelect,
     HasBinding, IsReadonly, HasConverter, HasLabelLayout,
     HasLabel, HasValidator, HasValueChangeListener,
-    HasValidatorMessage, HasConverterMessage, HasRequiredMessageForSelect, HasTabIndex, IsFocus, IsVisual {
+    HasValidatorMessage, HasConverterMessage, HasRequiredMessageForSelect, HasTabIndex, IsFocus, IsVisual,
+    HasAutoSpacing {
 
   /**
    * The value of the multi select.

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectManyListboxTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectManyListboxTagDeclaration.java
@@ -41,6 +41,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasTip;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidator;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidatorMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValueChangeListener;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabled;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsFocus;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsReadonly;
@@ -83,7 +84,8 @@ import javax.faces.component.UISelectMany;
 public interface SelectManyListboxTagDeclaration
     extends HasId, IsDisabled, IsRendered, HasBinding, HasTip, HasHelp,
     IsReadonly, HasConverter, IsRequiredForSelect, HasLabel, HasValidator, HasValueChangeListener, HasLabelLayout,
-    HasValidatorMessage, HasConverterMessage, HasRequiredMessageForSelect, HasTabIndex, IsFocus, IsVisual, HasSize {
+    HasValidatorMessage, HasConverterMessage, HasRequiredMessageForSelect, HasTabIndex, IsFocus, IsVisual, HasSize,
+    HasAutoSpacing {
 
   /**
    * The value of the multi select.

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectManyShuttleTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectManyShuttleTagDeclaration.java
@@ -42,6 +42,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasTip;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidator;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidatorMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValueChangeListener;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabled;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsFocus;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsReadonly;
@@ -83,7 +84,8 @@ import javax.faces.component.UISelectMany;
 public interface SelectManyShuttleTagDeclaration extends
     IsDisabled, HasId, HasTip, HasHelp, IsRendered, IsRequiredForSelect, HasBinding, IsReadonly, HasConverter,
     HasLabel, HasValidator, HasValueChangeListener, HasLabelLayout,
-    HasValidatorMessage, HasConverterMessage, HasRequiredMessageForSelect, HasTabIndex, IsFocus, IsVisual, HasSize {
+    HasValidatorMessage, HasConverterMessage, HasRequiredMessageForSelect, HasTabIndex, IsFocus, IsVisual, HasSize,
+    HasAutoSpacing {
 
   /**
    * The value of the multi select.

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectOneChoiceTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectOneChoiceTagDeclaration.java
@@ -41,6 +41,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidator;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidatorMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValue;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValueChangeListener;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabled;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsFocus;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsReadonly;
@@ -79,7 +80,7 @@ import javax.faces.component.UISelectOne;
 public interface SelectOneChoiceTagDeclaration
     extends HasValidator, HasValue, HasValueChangeListener, HasTabIndex, IsFocus, IsVisual,
     HasValidatorMessage, HasConverterMessage, HasRequiredMessage, HasId, IsDisabled, IsReadonly, HasLabel,
-    IsRendered, HasConverter, HasBinding, HasTip, HasHelp, HasLabelLayout {
+    IsRendered, HasConverter, HasBinding, HasTip, HasHelp, HasLabelLayout, HasAutoSpacing {
 
   /**
    * Flag indicating that selecting an Item representing a value is required.

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectOneListboxTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectOneListboxTagDeclaration.java
@@ -43,6 +43,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidator;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidatorMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValue;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValueChangeListener;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabled;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsFocus;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsReadonly;
@@ -87,7 +88,7 @@ import javax.faces.component.UISelectOne;
 public interface SelectOneListboxTagDeclaration
     extends HasValidator, HasValue, HasValueChangeListener, HasTabIndex, IsFocus, IsVisual,
     HasValidatorMessage, HasConverterMessage, HasRequiredMessage, HasId, IsDisabled, IsReadonly, HasLabel, IsRendered,
-    HasBinding, HasTip, HasHelp, HasConverter, HasLabelLayout, HasSize {
+    HasBinding, HasTip, HasHelp, HasConverter, HasLabelLayout, HasSize, HasAutoSpacing {
 
   /**
    * Flag indicating that selecting an Item representing a Value is Required.

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectOneRadioTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SelectOneRadioTagDeclaration.java
@@ -42,6 +42,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidator;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidatorMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValue;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValueChangeListener;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabled;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsFocus;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsInline;
@@ -81,7 +82,7 @@ import javax.faces.component.UISelectOne;
 public interface SelectOneRadioTagDeclaration
     extends HasValidator, HasValue, HasValueChangeListener, HasTabIndex, IsFocus, IsVisual,
     HasValidatorMessage, HasConverterMessage, HasRequiredMessage, IsDisabled, IsReadonly, HasId, HasTip, HasHelp,
-    IsInline, HasRenderRange, IsRendered, HasBinding, HasConverter, HasLabel, HasLabelLayout {
+    IsInline, HasRenderRange, IsRendered, HasBinding, HasConverter, HasLabel, HasLabelLayout, HasAutoSpacing {
 
   /**
    * Flag indicating that selecting an Item representing a Value is Required.

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/StarsTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/StarsTagDeclaration.java
@@ -41,6 +41,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidator;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidatorMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValue;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValueChangeListener;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabled;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsFocus;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsReadonly;
@@ -72,7 +73,8 @@ import javax.faces.component.UIInput;
 
 public interface StarsTagDeclaration extends HasIdBindingAndRendered, HasConverter, HasConverterMessage, IsDisabled,
     IsFocus, HasTabIndex, HasLabel, HasLabelLayout, IsReadonly, IsRequired, HasRequiredMessage, HasTip,
-    HasValidator, HasValidatorMessage, HasValue, HasValueChangeListener, IsVisual, HasAccessKey, HasHelp {
+    HasValidator, HasValidatorMessage, HasValue, HasValueChangeListener, IsVisual, HasAccessKey, HasHelp,
+    HasAutoSpacing {
 
   /**
    * The current value of this component. May be a java.lang.Number or a javax.swing.BoundedRangeModel

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/TabGroupTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/TabGroupTagDeclaration.java
@@ -33,6 +33,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasAction;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasActionListener;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasIdBindingAndRendered;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasTip;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsImmediateCommand;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsVisual;
 import org.apache.myfaces.tobago.model.SwitchType;
@@ -62,7 +63,8 @@ import javax.faces.component.UIPanel;
         )
     })
 public interface TabGroupTagDeclaration
-    extends HasIdBindingAndRendered, IsImmediateCommand, HasAction, HasActionListener, IsVisual, HasTip {
+    extends HasIdBindingAndRendered, IsImmediateCommand, HasAction, HasActionListener, IsVisual, HasTip,
+    HasAutoSpacing {
 
   /**
    * Flag indicating that the tab navigation bar is rendered.

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/TextareaTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/TextareaTagDeclaration.java
@@ -43,6 +43,7 @@ import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidator;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValidatorMessage;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValue;
 import org.apache.myfaces.tobago.internal.taglib.declaration.HasValueChangeListener;
+import org.apache.myfaces.tobago.internal.taglib.declaration.HasAutoSpacing;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsDisabled;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsFocus;
 import org.apache.myfaces.tobago.internal.taglib.declaration.IsReadonly;
@@ -83,7 +84,7 @@ import javax.faces.component.UIInput;
 public interface TextareaTagDeclaration
     extends HasIdBindingAndRendered, HasConverter, IsReadonly, IsDisabled, IsRequired, HasLabel, HasLabelLayout, HasTip,
     HasHelp, HasAccessKey, HasValidator, HasValue, HasValueChangeListener, HasTabIndex, IsFocus, IsVisual,
-    HasValidatorMessage, HasConverterMessage, HasRequiredMessage, HasSanitize, HasPlaceholder {
+    HasValidatorMessage, HasConverterMessage, HasRequiredMessage, HasSanitize, HasPlaceholder, HasAutoSpacing {
 
   /**
    * The row count for this component.

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/declaration/HasAutoSpacing.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/declaration/HasAutoSpacing.java
@@ -17,21 +17,27 @@
  * under the License.
  */
 
-package org.apache.myfaces.tobago.internal.component;
+package org.apache.myfaces.tobago.internal.taglib.declaration;
 
-import org.apache.myfaces.tobago.component.SupportsAutoSpacing;
-import org.apache.myfaces.tobago.component.SupportsDisabled;
-import org.apache.myfaces.tobago.layout.Orientation;
+import org.apache.myfaces.tobago.apt.annotation.TagAttribute;
+import org.apache.myfaces.tobago.apt.annotation.UIComponentTagAttribute;
 
-/**
- * {@link org.apache.myfaces.tobago.internal.taglib.component.ButtonsTagDeclaration}
- */
-public abstract class AbstractUIButtons extends AbstractUIPanelBase implements SupportsAutoSpacing, SupportsDisabled {
-
-  enum PropertyKeys {
-    disabled,
-  }
-
-  public abstract Orientation getOrientation();
-
+public interface HasAutoSpacing {
+  /**
+   * Automatically add spacing (margins/paddings) to the component for better positioning.
+   * Default is 'true' except the component is inside a:
+   * - header
+   * - footer
+   * - bar
+   * - sheet
+   * - link group
+   * - button group
+   * - before facet
+   * - after facet
+   * - label facet
+   * - bar facet
+   */
+  @TagAttribute
+  @UIComponentTagAttribute(type = "java.lang.Boolean")
+  void setAutoSpacing(String autoSpacing);
 }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/renderkit/css/TobagoClass.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/renderkit/css/TobagoClass.java
@@ -67,7 +67,7 @@ public enum TobagoClass implements CssItem {
    */
   @Deprecated
   ALIGN_ITEMS__STRETCH("tobago-alignItems-stretch"),
-
+  AUTO__SPACING("tobago-auto-spacing"),
   /**
    * @deprecated since 4.0.0, use {@link BootstrapClass#JUSTIFY_CONTENT_CENTER}
    */
@@ -159,7 +159,6 @@ public enum TobagoClass implements CssItem {
   LABEL("tobago-label"),
   LABEL__CONTAINER("tobago-label-container"),
   LINK("tobago-link"),
-  MARGIN__BOTTOM("tobago-margin-bottom"),
   MESSAGES("tobago-messages"),
   /**
    * @deprecated Since 5.0.0. Please use surrounding tag &lt;tobago-popover&gt;.

--- a/tobago-core/src/test/resources/renderer/box/box-label-facet.html
+++ b/tobago-core/src/test/resources/renderer/box/box-label-facet.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-box class='card' id='id'>
+<tobago-box class='card tobago-auto-spacing' id='id'>
   <div class='card-header tobago-box-header'>
     <h3>label
     </h3>

--- a/tobago-core/src/test/resources/renderer/box/box-label.html
+++ b/tobago-core/src/test/resources/renderer/box/box-label.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-box class='card' id='id'>
+<tobago-box class='card tobago-auto-spacing' id='id'>
   <div class='card-header tobago-box-header'>
     <h3>label
     </h3>

--- a/tobago-core/src/test/resources/renderer/box/simple.html
+++ b/tobago-core/src/test/resources/renderer/box/simple.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-box class='card' id='id'>
+<tobago-box class='card tobago-auto-spacing' id='id'>
   <div class='card-body'>
   </div>
 </tobago-box>

--- a/tobago-core/src/test/resources/renderer/buttons/badge-inside-buttons.html
+++ b/tobago-core/src/test/resources/renderer/buttons/badge-inside-buttons.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-buttons id='list' class='btn-group' role='group'>
+<tobago-buttons id='list' class='btn-group tobago-auto-spacing' role='group'>
   <tobago-badge id='badge' class='badge bg-secondary btn'>
   </tobago-badge>
   <button type='button' id='id' name='id' class='tobago-button btn btn-secondary'><tobago-behavior event='click' client-id='id'></tobago-behavior><span>button</span></button>

--- a/tobago-core/src/test/resources/renderer/buttons/separator-inside-buttons.html
+++ b/tobago-core/src/test/resources/renderer/buttons/separator-inside-buttons.html
@@ -17,7 +17,7 @@
 <!--
 CSS class of "tobago-dropdown" has changed from btn-group to dropdown
 -->
-<tobago-buttons id='list' class='btn-group' role='group'>
+<tobago-buttons id='list' class='btn-group tobago-auto-spacing' role='group'>
   <tobago-dropdown id='id' class='dropdown btn-group'>
     <button type='button' id='id::command' name='id' data-bs-toggle='dropdown' aria-expanded='false' class='tobago-button btn btn-secondary dropdown-toggle'><tobago-behavior event='click' client-id='id' field-id='id::command'></tobago-behavior><span>button</span></button>
     <div class='dropdown-menu' aria-labelledby='id::command' name='id'>

--- a/tobago-core/src/test/resources/renderer/date/date-label.html
+++ b/tobago-core/src/test/resources/renderer/date/date-label.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-date id='id' class='tobago-label-container tobago-margin-bottom' pattern='dd.mm.yyyy' i18n='{"months":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthsShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"days":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"daysShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"daysMin":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"firstDay":0,"minDays":1,"today":"Today","cancel":"Cancel","clear":"Clear","week":"Week"}'>
+<tobago-date id='id' class='tobago-label-container tobago-auto-spacing' pattern='dd.mm.yyyy' i18n='{"months":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthsShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"days":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"daysShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"daysMin":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"firstDay":0,"minDays":1,"today":"Today","cancel":"Cancel","clear":"Clear","week":"Week"}'>
   <label for='id::field' class='col-form-label'>Label</label>
   <div class='tobago-input-group-outer'>
     <div class='input-group'>

--- a/tobago-core/src/test/resources/renderer/date/date-today-button.html
+++ b/tobago-core/src/test/resources/renderer/date/date-today-button.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-date id='id' class='tobago-label-container tobago-margin-bottom' pattern='dd.mm.yyyy' i18n='{"months":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthsShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"days":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"daysShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"daysMin":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"firstDay":0,"minDays":1,"today":"Today","cancel":"Cancel","clear":"Clear","week":"Week"}' today-button='today-button'>
+<tobago-date id='id' class='tobago-label-container tobago-auto-spacing' pattern='dd.mm.yyyy' i18n='{"months":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthsShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"days":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"daysShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"daysMin":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"firstDay":0,"minDays":1,"today":"Today","cancel":"Cancel","clear":"Clear","week":"Week"}' today-button='today-button'>
   <label for='id::field' class='col-form-label'>Label</label>
   <div class='tobago-input-group-outer'>
     <div class='input-group'>

--- a/tobago-core/src/test/resources/renderer/date/date.html
+++ b/tobago-core/src/test/resources/renderer/date/date.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-date id='id' class='tobago-margin-bottom' pattern='dd.mm.yyyy' i18n='{"months":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthsShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"days":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"daysShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"daysMin":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"firstDay":0,"minDays":1,"today":"Today","cancel":"Cancel","clear":"Clear","week":"Week"}'>
+<tobago-date id='id' class='tobago-auto-spacing' pattern='dd.mm.yyyy' i18n='{"months":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthsShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"days":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"daysShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"daysMin":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"firstDay":0,"minDays":1,"today":"Today","cancel":"Cancel","clear":"Clear","week":"Week"}'>
   <div class='tobago-input-group-outer'>
     <div class='input-group'>
       <input type='text' name='id' id='id::field' class='form-control'>

--- a/tobago-core/src/test/resources/renderer/file/file-label.html
+++ b/tobago-core/src/test/resources/renderer/file/file-label.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-file id='id' class='tobago-label-container tobago-margin-bottom'>
+<tobago-file id='id' class='tobago-label-container tobago-auto-spacing'>
   <label for='id::field' class='col-form-label'>label</label>
   <div class='input-group'>
     <input type='file' tabindex='-1' id='id::field' class='form-control' name='id'>

--- a/tobago-core/src/test/resources/renderer/in/ajax.html
+++ b/tobago-core/src/test/resources/renderer/in/ajax.html
@@ -16,12 +16,12 @@
 -->
 
 <tobago-panel id='panel'>
-  <tobago-in id='id' class='tobago-label-container tobago-margin-bottom'>
+  <tobago-in id='id' class='tobago-label-container tobago-auto-spacing'>
     <label for='id::field' class='col-form-label'>label</label>
     <input type='text' name='id' id='id::field' class='tobago-in form-control'>
     <tobago-behavior event='change' client-id='id' field-id='id::field' execute='textarea id' render='panel'></tobago-behavior>
   </tobago-in>
-  <tobago-textarea id='textarea' class='tobago-margin-bottom'>
+  <tobago-textarea id='textarea' class='tobago-auto-spacing'>
     <textarea name='textarea' id='textarea::field' class='form-control'></textarea>
   </tobago-textarea>
 </tobago-panel>

--- a/tobago-core/src/test/resources/renderer/in/error-message.html
+++ b/tobago-core/src/test/resources/renderer/in/error-message.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-label-container tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-label-container tobago-auto-spacing'>
   <label for='id::field' class='col-form-label'>label</label>
   <div class='tobago-messages-container'>
     <input type='text' name='id' id='id::field' title='a test' class='tobago-in border-danger form-control' autofocus='autofocus'>

--- a/tobago-core/src/test/resources/renderer/in/help.html
+++ b/tobago-core/src/test/resources/renderer/in/help.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-label-container tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-label-container tobago-auto-spacing'>
   <label for='id::field' class='col-form-label'>label</label>
   <div class='tobago-messages-container'>
     <input type='text' name='id' id='id::field' class='tobago-in form-control'>

--- a/tobago-core/src/test/resources/renderer/in/input-group-button-after.html
+++ b/tobago-core/src/test/resources/renderer/in/input-group-button-after.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <div class='tobago-input-group-outer'>
     <div class='input-group'>
       <input type='text' name='id' id='id::field' class='tobago-in form-control'>

--- a/tobago-core/src/test/resources/renderer/in/input-group-button-before.html
+++ b/tobago-core/src/test/resources/renderer/in/input-group-button-before.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <div class='tobago-input-group-outer'>
     <div class='input-group'>
       <button type='button' id='button' name='button' class='tobago-button btn btn-secondary'><tobago-behavior event='click' client-id='button'></tobago-behavior><span>button</span></button>

--- a/tobago-core/src/test/resources/renderer/in/input-group-choice-after.html
+++ b/tobago-core/src/test/resources/renderer/in/input-group-choice-after.html
@@ -15,11 +15,11 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <div class='tobago-input-group-outer'>
     <div class='input-group'>
       <input type='text' name='id' id='id::field' class='tobago-in form-control'>
-      <tobago-select-one-choice id='choice' class='form-select tobago-margin-bottom'>
+      <tobago-select-one-choice id='choice' class='form-select'>
         <select id='choice::field' name='choice' class='form-select'>
           <option value=''>Stratocaster
           </option>

--- a/tobago-core/src/test/resources/renderer/in/input-group-dropdown-after.html
+++ b/tobago-core/src/test/resources/renderer/in/input-group-dropdown-after.html
@@ -17,7 +17,7 @@
 <!--
 dropdown-menu-right is temporarily not here (in the div with dropdown-menu), XXX might be to fixed?
 -->
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <div class='tobago-input-group-outer'>
     <div class='input-group'>
       <input type='text' name='id' id='id::field' class='tobago-in form-control'>

--- a/tobago-core/src/test/resources/renderer/in/input-group-dropdown-before.html
+++ b/tobago-core/src/test/resources/renderer/in/input-group-dropdown-before.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <div class='tobago-input-group-outer'>
     <div class='input-group'>
       <tobago-dropdown id='button' class='dropdown'>

--- a/tobago-core/src/test/resources/renderer/in/input-group-out-after.html
+++ b/tobago-core/src/test/resources/renderer/in/input-group-out-after.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <div class='tobago-input-group-outer'>
     <div class='input-group'>
       <input type='text' name='id' id='id::field' class='tobago-in form-control'>

--- a/tobago-core/src/test/resources/renderer/in/input-group-out-before.html
+++ b/tobago-core/src/test/resources/renderer/in/input-group-out-before.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <div class='tobago-input-group-outer'>
     <div class='input-group'>
       <tobago-out class='input-group-text'>out</tobago-out>

--- a/tobago-core/src/test/resources/renderer/in/label-flexLeft.html
+++ b/tobago-core/src/test/resources/renderer/in/label-flexLeft.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-label-container tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-label-container tobago-auto-spacing'>
   <label for='id::field' class='col-form-label'>label</label>
   <input type='text' name='id' id='id::field' class='tobago-in form-control'>
 </tobago-in>

--- a/tobago-core/src/test/resources/renderer/in/label-flexRight.html
+++ b/tobago-core/src/test/resources/renderer/in/label-flexRight.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-label-container tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-label-container tobago-auto-spacing'>
   <input type='text' name='id' id='id::field' class='tobago-in form-control'>
   <label for='id::field' class='col-form-label'>label</label>
 </tobago-in>

--- a/tobago-core/src/test/resources/renderer/in/label-flowLeft.html
+++ b/tobago-core/src/test/resources/renderer/in/label-flowLeft.html
@@ -16,6 +16,6 @@
 -->
 
 <label for='id::field' class='col-form-label'>label</label>
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <input type='text' name='id' id='id::field' class='tobago-in form-control'>
 </tobago-in>

--- a/tobago-core/src/test/resources/renderer/in/label-flowRight.html
+++ b/tobago-core/src/test/resources/renderer/in/label-flowRight.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <input type='text' name='id' id='id::field' class='tobago-in form-control'>
 </tobago-in>
 <label for='id::field' class='col-form-label'>label</label>

--- a/tobago-core/src/test/resources/renderer/in/label-gridBottom.html
+++ b/tobago-core/src/test/resources/renderer/in/label-gridBottom.html
@@ -16,6 +16,6 @@
 -->
 
 <label for='id::field' class='col-form-label'>label</label>
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <input type='text' name='id' id='id::field' class='tobago-in form-control'>
 </tobago-in>

--- a/tobago-core/src/test/resources/renderer/in/label-gridLeft.html
+++ b/tobago-core/src/test/resources/renderer/in/label-gridLeft.html
@@ -16,6 +16,6 @@
 -->
 
 <label for='id::field' class='col-form-label'>label</label>
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <input type='text' name='id' id='id::field' class='tobago-in form-control'>
 </tobago-in>

--- a/tobago-core/src/test/resources/renderer/in/label-gridRight.html
+++ b/tobago-core/src/test/resources/renderer/in/label-gridRight.html
@@ -16,6 +16,6 @@
 -->
 
 <label for='id::field' class='col-form-label'>label</label>
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <input type='text' name='id' id='id::field' class='tobago-in form-control'>
 </tobago-in>

--- a/tobago-core/src/test/resources/renderer/in/label-gridTop.html
+++ b/tobago-core/src/test/resources/renderer/in/label-gridTop.html
@@ -16,6 +16,6 @@
 -->
 
 <label for='id::field' class='col-form-label'>label</label>
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <input type='text' name='id' id='id::field' class='tobago-in form-control'>
 </tobago-in>

--- a/tobago-core/src/test/resources/renderer/in/label-none.html
+++ b/tobago-core/src/test/resources/renderer/in/label-none.html
@@ -15,6 +15,6 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <input type='text' name='id' id='id::field' class='tobago-in form-control'>
 </tobago-in>

--- a/tobago-core/src/test/resources/renderer/in/label-segmentLeft.html
+++ b/tobago-core/src/test/resources/renderer/in/label-segmentLeft.html
@@ -20,7 +20,7 @@
     <label for='id::field' class='col-form-label'>label</label>
   </div>
   <div class='col-md-9'>
-    <tobago-in id='id' class='tobago-margin-bottom'>
+    <tobago-in id='id' class='tobago-auto-spacing'>
       <input type='text' name='id' id='id::field' class='tobago-in form-control'>
     </tobago-in>
   </div>

--- a/tobago-core/src/test/resources/renderer/in/label-segmentRight.html
+++ b/tobago-core/src/test/resources/renderer/in/label-segmentRight.html
@@ -17,7 +17,7 @@
 
 <tobago-segment-layout id='segid' class='row'>
   <div class='col-md-9'>
-    <tobago-in id='id' class='tobago-margin-bottom'>
+    <tobago-in id='id' class='tobago-auto-spacing'>
       <input type='text' name='id' id='id::field' class='tobago-in form-control'>
     </tobago-in>
   </div>

--- a/tobago-core/src/test/resources/renderer/in/label-skip.html
+++ b/tobago-core/src/test/resources/renderer/in/label-skip.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <label for='id::field' class='col-form-label'>label</label>
   <input type='text' name='id' id='id::field' class='tobago-in form-control'>
 </tobago-in>

--- a/tobago-core/src/test/resources/renderer/in/label-top.html
+++ b/tobago-core/src/test/resources/renderer/in/label-top.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <label for='id::field' class='col-form-label'>label</label>
   <input type='text' name='id' id='id::field' class='tobago-in form-control'>
 </tobago-in>

--- a/tobago-core/src/test/resources/renderer/in/simple.html
+++ b/tobago-core/src/test/resources/renderer/in/simple.html
@@ -15,6 +15,6 @@
  * limitations under the License.
 -->
 
-<tobago-in id='id' class='tobago-margin-bottom'>
+<tobago-in id='id' class='tobago-auto-spacing'>
   <input type='text' name='id' id='id::field' class='tobago-in form-control'>
 </tobago-in>

--- a/tobago-core/src/test/resources/renderer/link/booleanInsideLink.html
+++ b/tobago-core/src/test/resources/renderer/link/booleanInsideLink.html
@@ -16,7 +16,7 @@
 -->
 
 <tobago-dropdown id='id' class='dropdown'>
-  <button type='button' id='id::command' name='id' data-bs-toggle='dropdown' aria-expanded='false' class='tobago-link btn btn-link dropdown-toggle'><tobago-behavior event='click' client-id='id' field-id='id::command'></tobago-behavior><span>dropdown</span></button>
+  <button type='button' id='id::command' name='id' data-bs-toggle='dropdown' aria-expanded='false' class='tobago-link btn btn-link tobago-auto-spacing dropdown-toggle'><tobago-behavior event='click' client-id='id' field-id='id::command'></tobago-behavior><span>dropdown</span></button>
   <div class='dropdown-menu' aria-labelledby='id::command' name='id'>
     <tobago-select-boolean-checkbox id='id' class='form-check dropdown-item'>
       <input class='form-check-input' type='checkbox' value='true' name='id' id='id::field'>

--- a/tobago-core/src/test/resources/renderer/link/link.html
+++ b/tobago-core/src/test/resources/renderer/link/link.html
@@ -15,4 +15,4 @@
  * limitations under the License.
 -->
 
-<a id='id' name='id' href='https://www.apache.org/' class='tobago-link'><tobago-behavior event='click' client-id='id' omit='omit'></tobago-behavior><span>label</span></a>
+<a id='id' name='id' href='https://www.apache.org/' class='tobago-link tobago-auto-spacing'><tobago-behavior event='click' client-id='id' omit='omit'></tobago-behavior><span>label</span></a>

--- a/tobago-core/src/test/resources/renderer/link/manyInsideLink.html
+++ b/tobago-core/src/test/resources/renderer/link/manyInsideLink.html
@@ -16,7 +16,7 @@
 -->
 
 <tobago-dropdown id='id' class='dropdown'>
-  <button type='button' id='id::command' name='id' data-bs-toggle='dropdown' aria-expanded='false' class='tobago-link btn btn-link dropdown-toggle'><tobago-behavior event='click' client-id='id' field-id='id::command'></tobago-behavior><span>dropdown</span></button>
+  <button type='button' id='id::command' name='id' data-bs-toggle='dropdown' aria-expanded='false' class='tobago-link btn btn-link tobago-auto-spacing dropdown-toggle'><tobago-behavior event='click' client-id='id' field-id='id::command'></tobago-behavior><span>dropdown</span></button>
   <div class='dropdown-menu' aria-labelledby='id::command' name='id'>
     <tobago-select-many-checkbox>
       <div class='form-check dropdown-item'>

--- a/tobago-core/src/test/resources/renderer/link/radioInsideLink.html
+++ b/tobago-core/src/test/resources/renderer/link/radioInsideLink.html
@@ -16,7 +16,7 @@
 -->
 
 <tobago-dropdown id='id' class='dropdown'>
-  <button type='button' id='id::command' name='id' data-bs-toggle='dropdown' aria-expanded='false' class='tobago-link btn btn-link dropdown-toggle'><tobago-behavior event='click' client-id='id' field-id='id::command'></tobago-behavior><span>dropdown</span></button>
+  <button type='button' id='id::command' name='id' data-bs-toggle='dropdown' aria-expanded='false' class='tobago-link btn btn-link tobago-auto-spacing dropdown-toggle'><tobago-behavior event='click' client-id='id' field-id='id::command'></tobago-behavior><span>dropdown</span></button>
   <div class='dropdown-menu' aria-labelledby='id::command' name='id'>
     <tobago-select-one-radio>
       <div class='form-check dropdown-item'>

--- a/tobago-core/src/test/resources/renderer/link/separatorInsideLink.html
+++ b/tobago-core/src/test/resources/renderer/link/separatorInsideLink.html
@@ -16,7 +16,7 @@
 -->
 
 <tobago-dropdown id='id' class='dropdown'>
-  <button type='button' id='id::command' name='id' data-bs-toggle='dropdown' aria-expanded='false' class='tobago-link btn btn-link dropdown-toggle'><tobago-behavior event='click' client-id='id' field-id='id::command'></tobago-behavior><span>dropdown</span></button>
+  <button type='button' id='id::command' name='id' data-bs-toggle='dropdown' aria-expanded='false' class='tobago-link btn btn-link tobago-auto-spacing dropdown-toggle'><tobago-behavior event='click' client-id='id' field-id='id::command'></tobago-behavior><span>dropdown</span></button>
   <div class='dropdown-menu' aria-labelledby='id::command' name='id'>
     <a id='link1' name='link1' href='https://www.apache.org/' class='tobago-link dropdown-item'><tobago-behavior event='click' client-id='link1' omit='omit'></tobago-behavior><span>Link 1</span></a>
     <tobago-separator id='separator' class='dropdown-divider'>

--- a/tobago-core/src/test/resources/renderer/links/link-inside-links-sub.html
+++ b/tobago-core/src/test/resources/renderer/links/link-inside-links-sub.html
@@ -17,7 +17,7 @@
 <!--
 CSS class nav-item has moved from "tobago-dropdown" to "li"
 -->
-<tobago-links id='list'>
+<tobago-links id='list' class='tobago-auto-spacing'>
   <ul class='nav'>
     <li class='nav-item'>
       <tobago-dropdown id='id' class='dropdown'>

--- a/tobago-core/src/test/resources/renderer/links/link-inside-links.html
+++ b/tobago-core/src/test/resources/renderer/links/link-inside-links.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-links id='list'>
+<tobago-links id='list' class='tobago-auto-spacing'>
   <ul class='nav'>
     <li class='nav-item'>
       <a id='id' name='id' href='https://www.apache.org/' class='tobago-link nav-link'><tobago-behavior event='click' client-id='id' omit='omit'></tobago-behavior><span>apache</span></a>

--- a/tobago-core/src/test/resources/renderer/range/range-label.html
+++ b/tobago-core/src/test/resources/renderer/range/range-label.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-range id='id' class='tobago-label-container tobago-margin-bottom'>
+<tobago-range id='id' class='tobago-label-container tobago-auto-spacing'>
   <label for='id::field' class='col-form-label'>label</label>
   <input type='range' name='id' id='id::field' min='0' max='100' step='1' class='tobago-in form-control'>
 </tobago-range>

--- a/tobago-core/src/test/resources/renderer/selectBooleanCheckbox/selectBooleanCheckboxItemLabel.html
+++ b/tobago-core/src/test/resources/renderer/selectBooleanCheckbox/selectBooleanCheckboxItemLabel.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-select-boolean-checkbox id='id' class='tobago-margin-bottom'>
+<tobago-select-boolean-checkbox id='id' class='tobago-auto-spacing'>
   <div class='form-check col-form-label'>
     <input class='form-check-input' type='checkbox' value='true' name='id' id='id::field'>
     <label class='form-check-label' for='id::field'>label</label>

--- a/tobago-core/src/test/resources/renderer/selectBooleanCheckbox/selectBooleanCheckboxLabel.html
+++ b/tobago-core/src/test/resources/renderer/selectBooleanCheckbox/selectBooleanCheckboxLabel.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-select-boolean-checkbox id='id' class='tobago-label-container tobago-margin-bottom'>
+<tobago-select-boolean-checkbox id='id' class='tobago-label-container tobago-auto-spacing'>
   <label for='id::field' class='col-form-label'>label</label>
   <div class='form-check col-form-label'>
     <input class='form-check-input' type='checkbox' value='true' name='id' id='id::field'>

--- a/tobago-core/src/test/resources/renderer/selectBooleanToggle/selectBooleanToggleItemLabel.html
+++ b/tobago-core/src/test/resources/renderer/selectBooleanToggle/selectBooleanToggleItemLabel.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-select-boolean-toggle id='id' class='tobago-margin-bottom'>
+<tobago-select-boolean-toggle id='id' class='tobago-auto-spacing'>
   <div class='form-check col-form-label form-switch'>
     <input class='form-check-input' type='checkbox' value='true' name='id' id='id::field'>
     <label class='form-check-label' for='id::field'>label</label>

--- a/tobago-core/src/test/resources/renderer/selectBooleanToggle/selectBooleanToggleLabel.html
+++ b/tobago-core/src/test/resources/renderer/selectBooleanToggle/selectBooleanToggleLabel.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-select-boolean-toggle id='id' class='tobago-label-container tobago-margin-bottom'>
+<tobago-select-boolean-toggle id='id' class='tobago-label-container tobago-auto-spacing'>
   <label for='id::field' class='col-form-label'>label</label>
   <div class='form-check col-form-label form-switch'>
     <input class='form-check-input' type='checkbox' value='true' name='id' id='id::field'>

--- a/tobago-core/src/test/resources/renderer/selectOneChoice/selectOneChoiceLabel.html
+++ b/tobago-core/src/test/resources/renderer/selectOneChoice/selectOneChoiceLabel.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-select-one-choice id='id' class='tobago-label-container tobago-margin-bottom'>
+<tobago-select-one-choice id='id' class='tobago-label-container tobago-auto-spacing'>
   <label for='id::field' class='col-form-label'>label</label>
   <select id='id::field' name='id' class='form-control'>
     <option value=''>Stratocaster

--- a/tobago-core/src/test/resources/renderer/selectOneRadio/selectOneRadioLabel.html
+++ b/tobago-core/src/test/resources/renderer/selectOneRadio/selectOneRadioLabel.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-select-one-radio id='id' class='tobago-label-container tobago-margin-bottom'>
+<tobago-select-one-radio id='id' class='tobago-label-container tobago-auto-spacing'>
   <label class='col-form-label'>label</label>
   <div>
     <div class='form-check'>

--- a/tobago-core/src/test/resources/renderer/textarea/with-label.html
+++ b/tobago-core/src/test/resources/renderer/textarea/with-label.html
@@ -15,7 +15,7 @@
  * limitations under the License.
 -->
 
-<tobago-textarea id='id' class='tobago-label-container tobago-margin-bottom'>
+<tobago-textarea id='id' class='tobago-label-container tobago-auto-spacing'>
   <label for='id::field' class='col-form-label'>label</label>
   <textarea name='id' id='id::field' class='form-control'></textarea>
 </tobago-textarea>

--- a/tobago-theme/src/main/scss/_tobago.scss
+++ b/tobago-theme/src/main/scss/_tobago.scss
@@ -124,6 +124,13 @@ $page-padding-top: 1rem;
   }
 }
 
+.tobago-auto-spacing {
+  /* Since bootstrap 5.0.0-alpha1 class "form-group" is removed. In the Bootstrap demo "form-group" is replaced with
+  "mb-3". But we shouldn't use "mb-3", because it's adding an "!important" to the margin-bottom. With "!important" added
+  custom styling is much more complicated. */
+  margin-bottom: $spacer;
+}
+
 /* badge -------------------------------------------------------------- */
 .tobago-badge {
 }
@@ -173,8 +180,6 @@ tobago-behavior {
 /* box -------------------------------------------------------------- */
 
 tobago-box {
-  margin-bottom: $card-spacer-y;
-
   > .card-body {
     overflow-x: hidden;
     overflow-y: auto;
@@ -475,11 +480,6 @@ tobago-in {
       /* fix style for surrounding container (tobago-select-one-choice).
       According to bootstrap docs, <select class=.form-select> should be rendered directly to .input-group. But tobago
       renders the tobago-select-one-choice custom tag (which contain the select component) inside an input group. */
-
-      &.tobago-margin-bottom {
-        margin-bottom: 0;
-      }
-
       &.form-select {
         padding: 0;
 
@@ -674,13 +674,6 @@ tobago-flex-layout.tobago-messages-container > {
   .tobago-input-group-outer, .tobago-selectManyShuttle {
     flex: 1 0 0px;
   }
-}
-
-.tobago-margin-bottom {
-  /* Since bootstrap 5.0.0-alpha1 class "form-group" is removed. In the Bootstrap demo "form-group" is replaced with
-  "mb-3". But we shouldn't use "mb-3", because it's adding an "!important" to the margin-bottom. With "!important" added
-  custom styling is much more complicated. */
-  margin-bottom: 1rem;
 }
 
 .tobago-messages {
@@ -1485,7 +1478,6 @@ tobago-tab.tobago-tab-barFacet {
 }
 
 tobago-tab-group {
-  margin-bottom: $spacer;
 }
 
 /* FIXME: This is to hide the toolbar, until it is implemented */


### PR DESCRIPTION
* implement auto spacing for:
  * labelLayout components
  * buttons and links
  * button and link groups
  * box
  * tab group
* add interfaces with default method for getAutoSpacing
* add insideBegin/End for tc:header, tc:footer, tc:sheet, label facet, bar facet, before/after facet
* rename .tobago-margin-bottom to a more general .tobago-auto-spacing
* remove margin-bottom style from tobago-box/tobago-tab-group; this is now done by
  .tobago-auto-spacing class
* adjust tests

The theme must be rebuild in a second commit.