### PR TITLE
fix(demo): enable websocket example

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/WebSocketController.java
+++ b/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/WebSocketController.java
@@ -23,12 +23,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.SessionScoped;
-//import javax.faces.push.Push;
-//import javax.faces.push.PushContext;
+import javax.faces.push.Push;
+import javax.faces.push.PushContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
+import java.time.LocalTime;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -42,8 +43,8 @@ public class WebSocketController implements Serializable {
   private ScheduledExecutorService scheduledExecutorService;
 
   @Inject
-//  @Push(channel = "clock")
-//  private PushContext push;
+  @Push(channel = "clock")
+  private PushContext push;
 
   public String startClock() {
     if (scheduledExecutorService == null || scheduledExecutorService.isShutdown()) {
@@ -53,7 +54,7 @@ public class WebSocketController implements Serializable {
     scheduledExecutorService.scheduleAtFixedRate(new Runnable() {
       @Override
       public void run() {
-//        push.send(LocalTime.now().toString());
+        push.send(LocalTime.now().toString());
       }
     }, 0, 17, TimeUnit.MILLISECONDS);
     return null;

--- a/tobago-example/tobago-example-demo/src/main/webapp/WEB-INF/tobago-config.xml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/WEB-INF/tobago-config.xml
@@ -49,7 +49,7 @@
 
   <content-security-policy mode="on">
     <!-- script-src: 'unsafe-inline' is required for WebSockets -->
-<!--    <directive name="script-src">'unsafe-inline'</directive>-->
+    <directive name="script-src">'unsafe-inline'</directive>
 
     <!-- needed for <tc:object> demo -->
     <directive name="child-src">https://www.openstreetmap.org</directive>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/30-concept/18-websocket/WebSocket.js
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/30-concept/18-websocket/WebSocket.js
@@ -16,5 +16,5 @@
  */
 
 function websocketListener(message, channel, event) {
-  document.getElementById("clockId").innerHTML = message + "<br/>";
+  document.getElementById("clockId").innerHTML = message;
 }

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/30-concept/18-websocket/WebSocket.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/30-concept/18-websocket/WebSocket.xhtml
@@ -25,15 +25,10 @@
   <p>Simple example for WebSockets.</p>
 
   <tc:section label="Example">
-    <p><tc:badge value="Warning" markup="warning"/>WebSockets are available since JSF 2.3</p>
-    <p><tc:badge value="Warning" markup="warning"/>CSP script-src: 'unsafe-inline' is needed.</p>
-    <p><tc:badge value="Warning" markup="warning"/>
-      WebSocket.xhtml: The comment for <code>&lt;f:websocket/></code> must be removed.</p>
-    <p><tc:badge value="Warning" markup="warning"/>
-      WebSocketController.java: The comment for 'push' and 'pushContext' must be removed.</p>
+    <p><tc:badge value="Warning" markup="warning"/> CSP script-src: 'unsafe-inline' is needed.</p>
 
     <tc:script file="#{request.contextPath}/content/30-concept/18-websocket/WebSocket.js"/>
-    <!--<f:websocket channel="clock" onmessage="websocketListener"/>-->
+    <f:websocket channel="clock" onmessage="websocketListener"/>
 
     <tc:buttons>
       <tc:button label="Start Clock" action="#{webSocketController.startClock}">


### PR DESCRIPTION
A requirement for f:websocket is JSF-2.3.
Since Tobago 5 required JSF-2.3, it's safe to enable the websocket example by default.