### PR TITLE
fix(demo): jetty with mojarra-2.3

### DIFF
--- a/tobago-example/pom.xml
+++ b/tobago-example/pom.xml
@@ -369,18 +369,6 @@
       <id>jetty</id>
       <dependencies>
         <dependency>
-          <groupId>org.apache.myfaces.core</groupId>
-          <artifactId>myfaces-api</artifactId>
-          <version>${myfaces23.version}</version>
-          <scope>compile</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.myfaces.core</groupId>
-          <artifactId>myfaces-impl</artifactId>
-          <version>${myfaces23.version}</version>
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>jcl-over-slf4j</artifactId>
         </dependency>


### PR DESCRIPTION
jetty can now be startet with -Djsf=mojarra-2.3.
Myfaces-2.3 is activated by default.

Issue: TOBAGO-2077