### PR TITLE
fix(tree): clientId with mojarra

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUITree.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUITree.java
@@ -30,6 +30,7 @@ import javax.el.ELContext;
 import javax.el.ValueExpression;
 import javax.faces.component.NamingContainer;
 import javax.faces.component.UIComponent;
+import javax.faces.component.UINamingContainer;
 import javax.faces.context.FacesContext;
 
 /**
@@ -40,6 +41,25 @@ public abstract class AbstractUITree extends AbstractUIData implements NamingCon
   public static final String SUFFIX_PARENT = "parent";
 
   private TreeState state;
+  private String baseClientId;
+
+  /**
+   * Workaround for mojarra: UIData.getClientId() returns the clientId + row index if an index is set.
+   * @return clientId without row index
+   */
+  public String getBaseClientId(final FacesContext facesContext) {
+    if (baseClientId == null) {
+      final String clientId = super.getClientId(facesContext);
+      final char separatorChar = UINamingContainer.getSeparatorChar(FacesContext.getCurrentInstance());
+      final String separatorRowIndex = separatorChar + String.valueOf(getRowIndex());
+      if (clientId.endsWith(separatorRowIndex)) {
+        baseClientId = clientId.substring(0, clientId.indexOf(separatorRowIndex));
+      } else {
+        baseClientId = clientId;
+      }
+    }
+    return baseClientId;
+  }
 
   @Override
   public void processValidators(final FacesContext facesContext) {

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TreeSelectRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TreeSelectRenderer.java
@@ -157,8 +157,8 @@ public class TreeSelectRenderer<T extends AbstractUITreeSelect> extends Renderer
         Map<ClientBehaviors, Command> other = behaviorCommands.getOther();
         if (other != null) {
           Command change = other.get(ClientBehaviors.change);
-          change.setExecute(change.getExecute() + " " + tree.getClientId(facesContext));
-          change.setRender(change.getRender() + " " + tree.getClientId(facesContext));
+          change.setExecute(change.getExecute() + " " + tree.getBaseClientId(facesContext));
+          change.setRender(change.getRender() + " " + tree.getBaseClientId(facesContext));
         }
       }
       encodeBehavior(writer, behaviorCommands);


### PR DESCRIPTION
Different behavior between myfaces and mojarra.
In mojarra UIData.getClientId() returns the clientId + row index if a row index is set. In myfaces
only the clientId is returned.
The method getBaseClientId() will always returns the clientId without a row index.

The incorrect clientId is the cause of a bug in TreeSelect where nodes are not deselected when
single selection is enabled.

Issue: TOBAGO-1910