### PR TITLE
fix(demo): Tag Library Documentation urls

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/010-input/80-stars/5_Star_Rating.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/010-input/80-stars/5_Star_Rating.xhtml
@@ -25,7 +25,7 @@
 
   <p>Use <code class="language-markup">&lt;tc:stars/></code> to create a five star rating.</p>
   <tc:link label="Tag Library Documentation" image="#{request.contextPath}/image/feather-leaf.png"
-           link="#{apiController.base}/doc/#{apiController.currentRelease}/tld/tc/stars.html"/>
+           link="#{apiController.tldBase}/#{apiController.currentRelease}/tld/tc/stars.html"/>
 
   <tc:section label="Basics">
     <tc:style marginTop="3rem"/>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/020-output/25-badge/Badge.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/020-output/25-badge/Badge.xhtml
@@ -31,7 +31,7 @@
              link="#{apiController.tldBase}/#{apiController.currentRelease}/tld/tc/badge.html"/>
     |
     <tc:link label="&lt;tc:button/>" image="#{request.contextPath}/image/feather-leaf.png"
-             link="#{apiController.base}/doc/#{apiController.currentRelease}/tld/tc/button.html"/></p>
+             link="#{apiController.tldBase}/#{apiController.currentRelease}/tld/tc/button.html"/></p>
 
   <tc:section label="Basics">
     <p>A simple badge rendered with <code class="language-markup">&lt;tc:badge value="Simple Badge"/></code>.</p>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/030-select/20-selectOneChoice/Dropdown.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/030-select/20-selectOneChoice/Dropdown.xhtml
@@ -33,11 +33,10 @@
              link="#{apiController.tldBase}/#{apiController.currentRelease}/tld/tc/selectOneChoice.html"/>
     |
     <tc:link label="&lt;tc:selectItem/>" image="#{request.contextPath}/image/feather-leaf.png"
-             link="#{apiController.base}/doc/#{apiController.currentRelease}/tld/tc/selectItem.html"/>
+             link="#{apiController.tldBase}/#{apiController.currentRelease}/tld/tc/selectItem.html"/>
     |
     <tc:link label="&lt;tc:selectItems/>" image="#{request.contextPath}/image/feather-leaf.png"
-             link="#{apiController.base}/doc/#{apiController.currentRelease}/tld/tc/selectItems.html"/></p>
-
+             link="#{apiController.tldBase}/#{apiController.currentRelease}/tld/tc/selectItems.html"/></p>
   <tc:section label="Basics">
     <p>Dropdown box with hardcoded items. The second item is disabled.
       To disable an item, use the <code>itemDisable</code> attribute.</p>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/050-container/60-bar/Bar.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/050-container/60-bar/Bar.xhtml
@@ -29,7 +29,7 @@
   <p>Additionally the facet <code class="language-markup">&lt;f:facet name="brand"/></code> can be added.
     It shows the 'brand', a logo, text or both on the left site of the bar.</p>
   <tc:link label="Tag Library Documentation" image="#{request.contextPath}/image/feather-leaf.png"
-           link="#{apiController.base}/doc/#{apiController.currentRelease}/tld/tc/bar.html"/>
+           link="#{apiController.tldBase}/#{apiController.currentRelease}/tld/tc/bar.html"/>
 
   <tc:section label="Example">
     <p>This example show a dark bar with a 'brand' facet, a menu and right side content inside an 'after' facet.</p>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/060-popup/Popup.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/20-component/060-popup/Popup.xhtml
@@ -30,10 +30,10 @@
              outcome="/content/30-concept/53-collapsible/Collapsible.xhtml"/> concept.</p>
   <p>Tag Library Documentation:
     <tc:link label="&lt;tc:popup/>" image="#{request.contextPath}/image/feather-leaf.png"
-             link="#{apiController.base}/doc/#{apiController.currentRelease}/tld/tc/popup.html"/>
+             link="#{apiController.tldBase}/#{apiController.currentRelease}/tld/tc/popup.html"/>
     |
     <tc:link label="&lt;tc:operation/>" image="#{request.contextPath}/image/feather-leaf.png"
-             link="#{apiController.base}/doc/#{apiController.currentRelease}/tld/tc/operation.html"/></p>
+             link="#{apiController.tldBase}/#{apiController.currentRelease}/tld/tc/operation.html"/></p>
 
   <tc:section label="Client Side Popup">
     <tc:form id="form2">


### PR DESCRIPTION
Some xhtmls contain the old apiController.base reference.
This is now replaced.

Issue: TOBAGO-2070