### PR TITLE
feat: icon for label of tab

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TabGroupRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TabGroupRenderer.java
@@ -290,7 +290,9 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
             labelEmpty = false;
           }
           if (label.getLabel() != null) {
+            writer.startElement(HtmlElements.SPAN);
             HtmlRendererUtils.writeLabelWithAccessKey(writer, label);
+            writer.endElement(HtmlElements.SPAN);
             labelEmpty = false;
           }
           if (labelFacet != null) {

--- a/tobago-theme/src/main/scss/_tobago.scss
+++ b/tobago-theme/src/main/scss/_tobago.scss
@@ -1506,6 +1506,11 @@ tobago-tab.tobago-tab-barFacet {
 }
 
 tobago-tab-group {
+  tobago-tab {
+    > .nav-link {
+      @include buttonLinkImageTextSpacing();
+    }
+  }
 }
 
 /* FIXME: This is to hide the toolbar, until it is implemented */


### PR DESCRIPTION
* tobago-tab label text should be rendered within a <span> according to tobago-link and
  tobago-button.
* add spacing between icon and label

Issue: TOBAGO-2085