### PR TITLE
fix(dropdown): styling

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/CommandRendererBase.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/CommandRendererBase.java
@@ -123,7 +123,7 @@ public abstract class CommandRendererBase<T extends AbstractUICommand> extends D
         dropdownSubmenu ? BootstrapClass.DROPDOWN_ITEM : null,
         parentOfCommands && !dropdownSubmenu ? BootstrapClass.DROPDOWN_TOGGLE : null,
         component.getCustomClass(),
-        isInside(facesContext, HtmlElements.TOBAGO_LINKS) ? BootstrapClass.NAV_LINK : null);
+        isInside(facesContext, HtmlElements.TOBAGO_LINKS) && !dropdownSubmenu ? BootstrapClass.NAV_LINK : null);
 
     final boolean defaultCommand = ComponentUtils.getBooleanAttribute(component, Attributes.defaultCommand);
     if (defaultCommand) {

--- a/tobago-core/src/test/resources/renderer/links/link-inside-links-sub.html
+++ b/tobago-core/src/test/resources/renderer/links/link-inside-links-sub.html
@@ -23,7 +23,7 @@ CSS class nav-item has moved from "tobago-dropdown" to "li"
       <tobago-dropdown id='id' class='dropdown'>
         <button type='button' id='id::command' name='id' data-bs-toggle='dropdown' aria-expanded='false' class='tobago-link btn btn-link dropdown-toggle nav-link'><tobago-behavior event='click' client-id='id' field-id='id::command'></tobago-behavior><span>apache</span></button>
         <div class='dropdown-menu' aria-labelledby='id::command' name='id'>
-          <a id='sub' name='sub' href='https://www.apache.org/' class='tobago-link dropdown-item nav-link'><tobago-behavior event='click' client-id='sub' omit='omit'></tobago-behavior><span>sub</span></a>
+          <a id='sub' name='sub' href='https://www.apache.org/' class='tobago-link dropdown-item'><tobago-behavior event='click' client-id='sub' omit='omit'></tobago-behavior><span>sub</span></a>
         </div>
       </tobago-dropdown>
     </li>


### PR DESCRIPTION
The "nav-link" class must not set in dropdown menus.
It result in wrong spacing for dropdown entries.
* test adjusted