### PR TITLE
build: CVE fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jsf.target>2.0</jsf.target>
     <required.maven.version>2.2.1</required.maven.version>
-    <checkstyle-rules.version>13</checkstyle-rules.version>
+    <checkstyle-rules.version>15-SNAPSHOT</checkstyle-rules.version>
     <tobago.basedir>${project.basedir}</tobago.basedir>
   </properties>
 

--- a/tobago-tool/tobago-tool-apt/pom.xml
+++ b/tobago-tool/tobago-tool-apt/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-      <version>1.10.9</version>
+      <version>1.10.11</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
* update ant (because of CVE-2021-36373, CVE-2021-36374)
* ignore jdom2 via suppression list