### PR TITLE
fix: icon regex pattern

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/renderkit/css/Icons.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/renderkit/css/Icons.java
@@ -53,10 +53,10 @@ public enum Icons implements CssItem {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private static final Pattern PATTERN = Pattern.compile("^(bi|fa|(fas|far|fal|fad)\\sfa)-[\\w\\d]+$");
-  private static final Pattern PATTERN_BI = Pattern.compile("^bi-[\\w\\d]+$");
-  private static final Pattern PATTERN_FA = Pattern.compile("^fa-[\\w\\d]+$");
-  private static final Pattern PATTERN_FA5 = Pattern.compile("^(fas|far|fal|fad)\\sfa-[\\w\\d]+$");
+  private static final Pattern PATTERN = Pattern.compile("^(bi|fa|(fas|far|fal|fad)\\sfa)-[\\w\\d-]+$");
+  private static final Pattern PATTERN_BI = Pattern.compile("^bi-[\\w\\d-]+$");
+  private static final Pattern PATTERN_FA = Pattern.compile("^fa-[\\w\\d-]+$");
+  private static final Pattern PATTERN_FA5 = Pattern.compile("^(fas|far|fal|fad)\\sfa-[\\w\\d-]+$");
 
   private final String clazz;
 

--- a/tobago-theme/tobago-theme-standard/src/test/java/org/apache/myfaces/tobago/renderkit/css/IconsUnitTest.java
+++ b/tobago-theme/tobago-theme-standard/src/test/java/org/apache/myfaces/tobago/renderkit/css/IconsUnitTest.java
@@ -61,6 +61,12 @@ public class IconsUnitTest {
   }
 
   @Test
+  public void iconFarFaAngleLeft() {
+    Assertions.assertTrue(Icons.matches("far fa-angle-left"));
+    Assertions.assertEquals("far fa-angle-left", Icons.custom("far fa-angle-left").getName());
+  }
+
+  @Test
   public void iconFal() {
     Assertions.assertTrue(Icons.matches("fal fa-code"));
     Assertions.assertEquals("fal fa-code", Icons.custom("fal fa-code").getName());


### PR DESCRIPTION
Regex patten doesn't recognize 'fa-angle-left' as a fontawesome icon.