### PR TITLE
fix: empty image attribute

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/util/HtmlRendererUtils.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/util/HtmlRendererUtils.java
@@ -74,7 +74,7 @@ public final class HtmlRendererUtils {
   }
 
   public static void encodeIconOrImage(final TobagoResponseWriter writer, final String image) throws IOException {
-    if (image != null) {
+    if (image != null && !image.isEmpty()) {
       if (Icons.matches(image)) {
         writer.startElement(HtmlElements.I);
         writer.writeClassAttribute(Icons.custom(image));

--- a/tobago-core/src/test/java/org/apache/myfaces/tobago/internal/renderkit/renderer/LinkRendererUnitTest.java
+++ b/tobago-core/src/test/java/org/apache/myfaces/tobago/internal/renderkit/renderer/LinkRendererUnitTest.java
@@ -64,6 +64,30 @@ public class LinkRendererUnitTest extends RendererTestBase {
   }
 
   @Test
+  public void linkWithImage() throws IOException {
+    final UILink c = (UILink) ComponentUtils.createComponent(
+      facesContext, Tags.link.componentType(), RendererTypes.Link, "id");
+    c.setLabel("label");
+    c.setImage("url");
+    c.setLink("https://www.apache.org/");
+    c.encodeAll(facesContext);
+
+    Assertions.assertEquals(loadHtml("renderer/link/linkWithImage.html"), formattedResult());
+  }
+
+  @Test
+  public void linkWithEmptyImage() throws IOException {
+    final UILink c = (UILink) ComponentUtils.createComponent(
+      facesContext, Tags.link.componentType(), RendererTypes.Link, "id");
+    c.setLabel("label");
+    c.setImage("");
+    c.setLink("https://www.apache.org/");
+    c.encodeAll(facesContext);
+
+    Assertions.assertEquals(loadHtml("renderer/link/link.html"), formattedResult());
+  }
+
+  @Test
   public void manyInsideLink() throws IOException {
     final UILink c = (UILink) ComponentUtils.createComponent(
         facesContext, Tags.link.componentType(), RendererTypes.Link, "id");

--- a/tobago-core/src/test/resources/renderer/link/linkWithImage.html
+++ b/tobago-core/src/test/resources/renderer/link/linkWithImage.html
@@ -1,0 +1,18 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+
+<a id='id' name='id' href='https://www.apache.org/' class='tobago-link tobago-auto-spacing'><tobago-behavior event='click' client-id='id' omit='omit'></tobago-behavior><img src='url' alt=''><span>label</span></a>


### PR DESCRIPTION
An empty image attribute on a tc:link should not render an IMG tag.

Issue: TOBAGO-2105