### PR TITLE
fix(tab): CSS customClass set on header/body

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TabGroupRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TabGroupRenderer.java
@@ -67,7 +67,7 @@ import java.util.Map;
 
 @ListenerFor(systemEventClass = PostAddToViewEvent.class)
 public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase<T>
-    implements ComponentSystemEventListener {
+  implements ComponentSystemEventListener {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -92,14 +92,14 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
           case reloadTab:
             final AjaxBehavior ajaxBehavior = new AjaxBehavior();
             final Collection<String> ids = Collections.singleton(
-                UINamingContainer.getSeparatorChar(facesContext) + tabGroup.getClientId(facesContext));
+              UINamingContainer.getSeparatorChar(facesContext) + tabGroup.getClientId(facesContext));
             ajaxBehavior.setExecute(ids);
             ajaxBehavior.setRender(ids);
             tab.addClientBehavior(click.name(), ajaxBehavior);
             break;
           case reloadPage:
             final AbstractUIEvent component = (AbstractUIEvent) ComponentUtils.createComponent(
-                facesContext, Tags.event.componentType(), RendererTypes.Event, "_click");
+              facesContext, Tags.event.componentType(), RendererTypes.Event, "_click");
             component.setEvent(click);
             tab.getChildren().add(component);
             final EventBehavior eventBehavior = new EventBehavior();
@@ -145,10 +145,10 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
     writer.startElement(HtmlElements.TOBAGO_TAB_GROUP);
     writer.writeIdAttribute(clientId);
     writer.writeClassAttribute(
-        BootstrapClass.CARD,
-        autoSpacing ? TobagoClass.AUTO__SPACING : null,
-        uiComponent.getCustomClass(),
-        markup != null && markup.contains(Markup.SPREAD) ? TobagoClass.SPREAD : null);
+      BootstrapClass.CARD,
+      autoSpacing ? TobagoClass.AUTO__SPACING : null,
+      uiComponent.getCustomClass(),
+      markup != null && markup.contains(Markup.SPREAD) ? TobagoClass.SPREAD : null);
     HtmlRendererUtils.writeDataAttributes(facesContext, writer, uiComponent);
     writer.writeAttribute(CustomAttributes.SWITCH_TYPE, switchType.name(), false);
 
@@ -207,9 +207,9 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
   }
 
   private void encodeHeader(
-      final FacesContext facesContext, final TobagoResponseWriter writer, final AbstractUITabGroup tabGroup,
-      final int selectedIndex, final SwitchType switchType)
-      throws IOException {
+    final FacesContext facesContext, final TobagoResponseWriter writer, final AbstractUITabGroup tabGroup,
+    final int selectedIndex, final SwitchType switchType)
+    throws IOException {
 
     final String tabGroupClientId = tabGroup.getClientId(facesContext);
 
@@ -217,9 +217,9 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
     writer.writeClassAttribute(BootstrapClass.CARD_HEADER);
     writer.startElement(HtmlElements.UL);
     writer.writeClassAttribute(
-        BootstrapClass.NAV,
-        BootstrapClass.NAV_TABS,
-        BootstrapClass.CARD_HEADER_TABS);
+      BootstrapClass.NAV,
+      BootstrapClass.NAV_TABS,
+      BootstrapClass.CARD_HEADER_TABS);
     writer.writeAttribute(HtmlAttributes.ROLE, HtmlRoleValues.TABLIST.toString(), false);
 
     int index = 0;
@@ -235,7 +235,7 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
           Markup markup = tab.getMarkup() != null ? tab.getMarkup() : Markup.NULL;
 
           final FacesMessage.Severity maxSeverity
-              = ComponentUtils.getMaximumSeverityOfChildrenMessages(facesContext, tab);
+            = ComponentUtils.getMaximumSeverityOfChildrenMessages(facesContext, tab);
           if (maxSeverity != null) {
             markup = markup.add(ComponentUtils.markupOfSeverity(maxSeverity));
           }
@@ -243,9 +243,9 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
           writer.startElement(HtmlElements.TOBAGO_TAB);
           writer.writeIdAttribute(tabId);
           writer.writeClassAttribute(
-              BootstrapClass.NAV_ITEM,
-              barFacet != null ? TobagoClass.BAR : null,
-              tab.getCustomClass());
+            BootstrapClass.NAV_ITEM,
+            barFacet != null ? TobagoClass.BAR : null,
+            tab.getCustomClass());
           writer.writeAttribute(HtmlAttributes.FOR, tabGroupClientId, true);
           writer.writeAttribute(HtmlAttributes.ROLE, HtmlRoleValues.PRESENTATION.toString(), false);
           writer.writeAttribute(CustomAttributes.INDEX, index);
@@ -268,7 +268,7 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
           if (!disabled && switchType == SwitchType.client) {
             writer.writeAttribute(HtmlAttributes.HREF, '#' + getTabPanelId(facesContext, tab), false);
             writer.writeAttribute(
-                DataAttributes.TARGET, '#' + getTabPanelId(facesContext, tab).replaceAll(":", "\\\\:"), false);
+              DataAttributes.TARGET, '#' + getTabPanelId(facesContext, tab).replaceAll(":", "\\\\:"), false);
           }
 
           if (!disabled && label.getAccessKey() != null) {
@@ -322,8 +322,8 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
   }
 
   protected void encodeContent(
-      final FacesContext facesContext, final TobagoResponseWriter writer, final AbstractUITabGroup tabGroup,
-      final int selectedIndex, final SwitchType switchType) throws IOException {
+    final FacesContext facesContext, final TobagoResponseWriter writer, final AbstractUITabGroup tabGroup,
+    final int selectedIndex, final SwitchType switchType) throws IOException {
     writer.startElement(HtmlElements.DIV);
     writer.writeClassAttribute(BootstrapClass.CARD_BODY, BootstrapClass.TAB_CONTENT);
     int index = 0;
@@ -335,8 +335,9 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
 
           writer.startElement(HtmlElements.DIV);
           writer.writeClassAttribute(
-              BootstrapClass.TAB_PANE,
-              index == selectedIndex ? BootstrapClass.ACTIVE : null);
+            BootstrapClass.TAB_PANE,
+            index == selectedIndex ? BootstrapClass.ACTIVE : null,
+            tab.getCustomClass());
           writer.writeAttribute(HtmlAttributes.ROLE, HtmlRoleValues.TABPANEL.toString(), false);
           writer.writeIdAttribute(getTabPanelId(facesContext, tab));
 

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/070-tab/Tab_Group.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/070-tab/Tab_Group.xhtml
@@ -32,16 +32,20 @@
   <tc:section label="Client side">
     <demo-highlight language="markup">&lt;tc:tabGroup></demo-highlight>
     <tc:tabGroup id="tabGroupClient">
-      <tc:tab id="tab1Client" label="Tab One" markup="one">
+      <tc:tab id="tab1Client" label="Tab One">
+        <tc:style customClass="one"/>
         Content of tab one.
       </tc:tab>
-      <tc:tab id="tab2Client" label="Tab Two" disabled="true" markup="two">
+      <tc:tab id="tab2Client" label="Tab Two" disabled="true">
+        <tc:style customClass="two"/>
         Content of tab two.
       </tc:tab>
-      <tc:tab id="tabNoneClient" label="Tab Not Rendered" rendered="false" markup="none">
+      <tc:tab id="tabNoneClient" label="Tab Not Rendered" rendered="false">
+        <tc:style customClass="none"/>
         This tab shouldn't be rendered.
       </tc:tab>
-      <tc:tab id="tab3Client" label="Tab Three" markup="three">
+      <tc:tab id="tab3Client" label="Tab Three">
+        <tc:style customClass="three"/>
         Content of tab three.
       </tc:tab>
     </tc:tabGroup>
@@ -50,16 +54,20 @@
   <tc:section label="AJAX">
     <demo-highlight language="markup">&lt;tabGroup switchType="reloadTab"></demo-highlight>
     <tc:tabGroup id="tabGroupAjax" switchType="reloadTab">
-      <tc:tab id="tab1Ajax" label="Tab One" markup="one">
+      <tc:tab id="tab1Ajax" label="Tab One">
+        <tc:style customClass="one"/>
         Content of tab one.
       </tc:tab>
-      <tc:tab id="tab2Ajax" label="Tab Two" disabled="true" markup="two">
+      <tc:tab id="tab2Ajax" label="Tab Two" disabled="true">
+        <tc:style customClass="two"/>
         Content of tab two.
       </tc:tab>
-      <tc:tab id="tabNoneAjax" label="Tab Not Rendered" rendered="false" markup="none">
+      <tc:tab id="tabNoneAjax" label="Tab Not Rendered" rendered="false">
+        <tc:style customClass="none"/>
         This tab shouldn't be rendered.
       </tc:tab>
-      <tc:tab id="tab3Ajax" label="Tab Three" markup="three">
+      <tc:tab id="tab3Ajax" label="Tab Three">
+        <tc:style customClass="three"/>
         Content of tab three.
       </tc:tab>
     </tc:tabGroup>
@@ -68,16 +76,20 @@
   <tc:section label="Server side">
     <demo-highlight language="markup">&lt;tabGroup switchType="reloadPage"></demo-highlight>
     <tc:tabGroup id="tabGroupFullReload" switchType="reloadPage">
-      <tc:tab id="tab1FullReload" label="Tab One" markup="one">
+      <tc:tab id="tab1FullReload" label="Tab One">
+        <tc:style customClass="one"/>
         Content of tab one.
       </tc:tab>
-      <tc:tab id="tab2FullReload" label="Tab Two" disabled="true" markup="two">
+      <tc:tab id="tab2FullReload" label="Tab Two" disabled="true">
+        <tc:style customClass="two"/>
         Content of tab two.
       </tc:tab>
-      <tc:tab id="tabNoneFullReload" label="Tab Not Rendered" rendered="false" markup="none">
+      <tc:tab id="tabNoneFullReload" label="Tab Not Rendered" rendered="false">
+        <tc:style customClass="none"/>
         This tab shouldn't be rendered.
       </tc:tab>
-      <tc:tab id="tab3FullReload" label="Tab Three" markup="three">
+      <tc:tab id="tab3FullReload" label="Tab Three">
+        <tc:style customClass="three"/>
         <f:facet name="bar">
           <demo-alert value="Not implemented yet!">
             <tc:link image="bi-x-lg" omit="true"/>


### PR DESCRIPTION
If a CSS customClass is set with <tc:style>, it will be now rendered on the header AND the body.

* adjust example

Issue: TOBAGO-2120