### PR TITLE
chore: ignore checkstyle 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -255,6 +255,9 @@ updates:
       - dependency-name: "org.seleniumhq.selenium:selenium-java"
         versions:
           - ">= 3.0.0"
+      - dependency-name: "com.puppycrawl.tools:checkstyle"
+        versions:
+          - ">= 10.0"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Ignore checkstyle 10 for tobago-2, because checkstyle 10 need java11