### PR TITLE
fix: AuthorizationHelper fails

### DIFF
--- a/tobago-core/src/test/java/org/apache/myfaces/tobago/internal/util/AuthorizationHelperUnitTest.java
+++ b/tobago-core/src/test/java/org/apache/myfaces/tobago/internal/util/AuthorizationHelperUnitTest.java
@@ -22,7 +22,7 @@ package org.apache.myfaces.tobago.internal.util;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class AuthorizationHelperTest {
+class AuthorizationHelperUnitTest {
 
   @Test
   public void testSkipBrackets() {


### PR DESCRIPTION
rename Test to UnitTest

issue: TOBAGO-2121