### PR TITLE
build: enforce newer maven version, by security reasons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <maven.compile.encoding>UTF-8</maven.compile.encoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jsf.target>2.0</jsf.target>
-    <required.maven.version>3.3.1</required.maven.version>
+    <required.maven.version>3.8.1</required.maven.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
     <checkstyle.version>9.3</checkstyle.version>
     <!-- XXX use 17, if released -->
@@ -427,7 +427,6 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <!-- 3.3.1 is only required for a release, for a normal build 2.2.1 should be okay -->
                   <version>${required.maven.version}</version>
                 </requireMavenVersion>
                 <requirePluginVersions>
@@ -552,7 +551,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.16.0</version>
+          <version>3.17.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -854,9 +853,6 @@
              </properties>
            </profile>
        -->
-      <properties>
-        <required.maven.version>3.3.1</required.maven.version>
-      </properties>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
* see https://nvd.nist.gov/vuln/detail/CVE-2021-26291