### PR TITLE
build: enforce newer maven version, by security reasons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <maven.compile.encoding>UTF-8</maven.compile.encoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <required.maven.version>3.0.4</required.maven.version>
+    <required.maven.version>3.8.1</required.maven.version>
     <maven-pmd-plugin.version>3.17.0</maven-pmd-plugin.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
     <checkstyle-rules.version>17-SNAPSHOT</checkstyle-rules.version>
@@ -402,7 +402,6 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <!-- 3.3.1 is only required for a release, for a normal build 3.0.4 should be okay -->
                   <version>${required.maven.version}</version>
                 </requireMavenVersion>
                 <requirePluginVersions>
@@ -885,9 +884,6 @@
              </properties>
            </profile>
        -->
-      <properties>
-        <required.maven.version>3.3.1</required.maven.version>
-      </properties>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
* see https://nvd.nist.gov/vuln/detail/CVE-2021-26291