### PR TITLE
build: Prepare for current environments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -505,7 +505,7 @@
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java15</artifactId>
+            <artifactId>java17</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>


### PR DESCRIPTION
* Remove Java 1.5 and 1.6 support and add Java 11 and 17 support for Tobago 2
* Tobago 2 should be compatible with Jakarta EE 8

issue: TOBAGO-2138
issue: TOBAGO-2136