### PR TITLE
build(deps): bump maven-archiver from 3.5.2 to 3.6.0

### DIFF
--- a/tobago-tool/tobago-theme-plugin/pom.xml
+++ b/tobago-tool/tobago-theme-plugin/pom.xml
@@ -52,7 +52,12 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-archiver</artifactId>
-      <version>3.5.2</version>
+      <version>3.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
In maven-archiver 3.6.0 the maven-core dependency is set on 'provided'. So it must be added.