### PR TITLE
fix: Wrong scroll position for client sided tab group

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TabGroupRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TabGroupRenderer.java
@@ -266,7 +266,6 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
             writer.writeClassAttribute(BootstrapClass.NAV_LINK);
           }
           if (!disabled && switchType == SwitchType.client) {
-            writer.writeAttribute(HtmlAttributes.HREF, '#' + getTabPanelId(facesContext, tab), false);
             writer.writeAttribute(
               DataAttributes.TARGET, '#' + getTabPanelId(facesContext, tab).replaceAll(":", "\\\\:"), false);
           }

--- a/tobago-core/src/test/resources/renderer/tabGroup/tabGroup-bar.html
+++ b/tobago-core/src/test/resources/renderer/tabGroup/tabGroup-bar.html
@@ -20,10 +20,10 @@
   <div class='card-header'>
     <ul class='nav nav-tabs card-header-tabs' role='tablist'>
       <tobago-tab id='t1' class='nav-item' for='id' role='presentation' index='0'>
-        <a data-toggle='tab' class='nav-link active' href='#t1::content' data-target='#t1\:\:content' role='tab'><span>T1</span></a>
+        <a data-toggle='tab' class='nav-link active' data-target='#t1\:\:content' role='tab'><span>T1</span></a>
       </tobago-tab>
       <tobago-tab id='t2' class='nav-item tobago-bar' for='id' role='presentation' index='1'>
-        <a data-toggle='tab' class='nav-link' href='#t2::content' data-target='#t2\:\:content' role='tab'><span>T2</span></a>
+        <a data-toggle='tab' class='nav-link' data-target='#t2\:\:content' role='tab'><span>T2</span></a>
         <div>
           <button type='button' id='t2:b' name='t2:b' class='tobago-button btn btn-secondary'><tobago-behavior event='click' client-id='t2:b'></tobago-behavior><span>B</span></button>
         </div>

--- a/tobago-core/src/test/resources/renderer/tabGroup/tabGroup-label.html
+++ b/tobago-core/src/test/resources/renderer/tabGroup/tabGroup-label.html
@@ -20,10 +20,10 @@
   <div class='card-header'>
     <ul class='nav nav-tabs card-header-tabs' role='tablist'>
       <tobago-tab id='t1' class='nav-item' for='id' role='presentation' index='0'>
-        <a data-toggle='tab' class='nav-link active' href='#t1::content' data-target='#t1\:\:content' role='tab'><span>T1</span></a>
+        <a data-toggle='tab' class='nav-link active' data-target='#t1\:\:content' role='tab'><span>T1</span></a>
       </tobago-tab>
       <tobago-tab id='t2' class='nav-item' for='id' role='presentation' index='1'>
-        <a data-toggle='tab' class='nav-link' href='#t2::content' data-target='#t2\:\:content' role='tab'><span>T2</span><tobago-out id='t2:o' class='tobago-label-container'><label for='t2:o' class='col-form-label'>Label</label><span class='form-control-plaintext'></span></tobago-out></a>
+        <a data-toggle='tab' class='nav-link' data-target='#t2\:\:content' role='tab'><span>T2</span><tobago-out id='t2:o' class='tobago-label-container'><label for='t2:o' class='col-form-label'>Label</label><span class='form-control-plaintext'></span></tobago-out></a>
       </tobago-tab>
     </ul>
   </div>

--- a/tobago-core/src/test/resources/renderer/tabGroup/tabGroup.html
+++ b/tobago-core/src/test/resources/renderer/tabGroup/tabGroup.html
@@ -20,10 +20,10 @@
   <div class='card-header'>
     <ul class='nav nav-tabs card-header-tabs' role='tablist'>
       <tobago-tab id='t1' class='nav-item' for='id' role='presentation' index='0'>
-        <a data-toggle='tab' class='nav-link active' href='#t1::content' data-target='#t1\:\:content' role='tab'><span>T1</span></a>
+        <a data-toggle='tab' class='nav-link active' data-target='#t1\:\:content' role='tab'><span>T1</span></a>
       </tobago-tab>
       <tobago-tab id='t2' class='nav-item' for='id' role='presentation' index='1'>
-        <a data-toggle='tab' class='nav-link' href='#t2::content' data-target='#t2\:\:content' role='tab'><span>T2</span></a>
+        <a data-toggle='tab' class='nav-link' data-target='#t2\:\:content' role='tab'><span>T2</span></a>
       </tobago-tab>
     </ul>
   </div>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/070-tab/00-client/Tab_Client.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/070-tab/00-client/Tab_Client.xhtml
@@ -43,7 +43,7 @@
       <tc:tab id="t11" label="One">
         First tab.
       </tc:tab>
-      <tc:tab id="t12" label="Two" disabled="true">
+      <tc:tab id="t12" label="Two (disabled)" disabled="true">
         Second tab.
       </tc:tab>
       <tc:tab id="t13" label="Three">

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/070-tab/02-server/Tab_Server.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/070-tab/02-server/Tab_Server.xhtml
@@ -44,7 +44,7 @@
       <tc:tab id="t11" label="One">
         First tab.
       </tc:tab>
-      <tc:tab id="t12" label="Two" disabled="true">
+      <tc:tab id="t12" label="Two (disabled)" disabled="true">
         Second tab.
       </tc:tab>
       <tc:tab id="t13" label="Three">

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/070-tab/Tab_Group.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/070-tab/Tab_Group.xhtml
@@ -36,7 +36,7 @@
         <tc:style customClass="one"/>
         Content of tab one.
       </tc:tab>
-      <tc:tab id="tab2Client" label="Tab Two" disabled="true">
+      <tc:tab id="tab2Client" label="Tab Two (disabled)" disabled="true">
         <tc:style customClass="two"/>
         Content of tab two.
       </tc:tab>
@@ -58,7 +58,7 @@
         <tc:style customClass="one"/>
         Content of tab one.
       </tc:tab>
-      <tc:tab id="tab2Ajax" label="Tab Two" disabled="true">
+      <tc:tab id="tab2Ajax" label="Tab Two (disabled)" disabled="true">
         <tc:style customClass="two"/>
         Content of tab two.
       </tc:tab>
@@ -80,7 +80,7 @@
         <tc:style customClass="one"/>
         Content of tab one.
       </tc:tab>
-      <tc:tab id="tab2FullReload" label="Tab Two" disabled="true">
+      <tc:tab id="tab2FullReload" label="Tab Two (disabled)" disabled="true">
         <tc:style customClass="two"/>
         Content of tab two.
       </tc:tab>


### PR DESCRIPTION
* href is not needed for this feature, because Bootstrap make the switch

issue: TOBAGO-2139