### PR TITLE
build: use at least Java 11 to build

### DIFF
--- a/.github/workflows/tobago-ci.yml
+++ b/.github/workflows/tobago-ci.yml
@@ -32,11 +32,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '8'
+          java-version: '11'
       - name: Cache Maven packages
         uses: actions/cache@v3
         with:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,9 +43,9 @@ pipeline {
                 axes {
                     axis {
                         name 'JAVA_VERSION'
-//                        values 'jdk_1.8_latest', 'jdk_11_latest', 'jdk_16_latest' 
-//                        XXX turned off because of Jenkins random fails
-                        values 'jdk_1.8_latest'
+//                        values 'jdk_11_latest', 'jdk_17_latest'
+//                        XXX turned off because of Jenkins randomly fails
+                        values 'jdk_1.11_latest'
                     }
                 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -408,8 +408,8 @@
                   </unCheckedPlugins>
                 </requirePluginVersions>
                 <requireJavaVersion>
-                  <message>Tobago must be compiled with Java 8 or higher</message>
-                  <version>[1.8,)</version>
+                  <message>Tobago must be built with Java 11 or higher</message>
+                  <version>[11,)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
Because of Logback 1.4 (for the UnitTests)
This not affect the Class Version (still Java 8)