### PR TITLE
ci(dependabot): ignore Logback 1.3 for Tobago <= 5.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -156,10 +156,10 @@ updates:
       - dependency-name: "org.slf4j:*"
         versions:
           - ">= 2.0.0"
-      # Logback >= 1.4 requires jdk 11
+      # Logback >= 1.3 requires SLF4J 2.x
       - dependency-name: "ch.qos.logback:*"
         versions:
-          - ">= 1.4.0"
+          - ">= 1.3.0"
 
   - package-ecosystem: "maven"
     directory: "/"
@@ -242,10 +242,10 @@ updates:
       - dependency-name: "org.slf4j:*"
         versions:
           - ">= 2.0.0"
-      # Logback >= 1.4 requires jdk 11
+      # Logback >= 1.3 requires SLF4J 2.x
       - dependency-name: "ch.qos.logback:*"
         versions:
-          - ">= 1.4.0"
+          - ">= 1.3.0"
 
   - package-ecosystem: "maven"
     directory: "/"
@@ -322,10 +322,10 @@ updates:
       - dependency-name: "org.slf4j:*"
         versions:
           - ">= 2.0.0"
-      # Logback >= 1.4 requires jdk 11
+      # Logback >= 1.3 requires SLF4J 2.x
       - dependency-name: "ch.qos.logback:*"
         versions:
-          - ">= 1.4.0"
+          - ">= 1.3.0"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
logback 1.3.x requires SLF4J 2.x.
Since we want to stay on SLF4J 1.x for a while, we must stay on logback 1.2.x as well.