### PR TITLE
build(deps): logback downgrade to 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <mojarra21.version>2.1.29-11</mojarra21.version>
     <mojarra22.version>2.2.20</mojarra22.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <logback.version>1.3.1</logback.version>
+    <logback.version>1.2.11</logback.version>
     <log4j.version>2.18.0</log4j.version>
     <commons-io.version>2.11.0</commons-io.version>
     <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
Downgrade logback version to 1.2.x because it works with slf4j 1.x.