### PR TITLE
style(editorconfig): fix indent for java files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,3 +25,7 @@ indent_size = 2
 end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+# Ignore indent_size for java files
+[*.java]
+indent_size = unset


### PR DESCRIPTION
The indent size for java files is mostly 2 spaces. But in some cases (linebreak in method header) it is 4 spaces. Therefore, a fixed indent size must not be applied to Java files.