### PR TITLE
feat: open-liberty maven profile

### DIFF
--- a/tobago-example/pom.xml
+++ b/tobago-example/pom.xml
@@ -90,6 +90,16 @@
     </pluginManagement>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.bval</groupId>
+        <artifactId>bval-jsr</artifactId>
+        <version>2.0.6</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.myfaces.tobago</groupId>
@@ -413,6 +423,11 @@
           <artifactId>jakarta.enterprise.cdi-api</artifactId>
           <scope>compile</scope>
         </dependency>
+        <dependency>
+          <groupId>org.apache.bval</groupId>
+          <artifactId>bval-jsr</artifactId>
+          <scope>compile</scope>
+        </dependency>
       </dependencies>
     </profile>
 
@@ -471,6 +486,11 @@
         <dependency>
           <groupId>jakarta.enterprise</groupId>
           <artifactId>jakarta.enterprise.cdi-api</artifactId>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.bval</groupId>
+          <artifactId>bval-jsr</artifactId>
           <scope>compile</scope>
         </dependency>
         <!-- this enables the development mode -->
@@ -541,6 +561,41 @@
       </build>
     </profile>
 
+    <profile>
+      <id>liberty</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.openliberty.tools</groupId>
+            <artifactId>liberty-maven-plugin</artifactId>
+            <version>3.7.1</version>
+            <configuration>
+              <serverXmlFile>${project.basedir}/src/test/liberty/config/server.xml</serverXmlFile>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.myfaces.core</groupId>
+          <artifactId>myfaces-api</artifactId>
+          <version>${myfaces23.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.myfaces.core</groupId>
+          <artifactId>myfaces-impl</artifactId>
+          <version>${myfaces23.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <!-- this enables the development mode -->
+        <dependency>
+          <groupId>org.apache.myfaces.tobago</groupId>
+          <artifactId>tobago-config-dev</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
     <!--
     todo: profile for meecromave?
     todo: profile for wildfly?

--- a/tobago-example/tobago-example-demo/pom.xml
+++ b/tobago-example/tobago-example-demo/pom.xml
@@ -207,11 +207,6 @@
       <artifactId>jakarta.validation-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.bval</groupId>
-      <artifactId>bval-jsr</artifactId>
-      <version>2.0.6</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
       <version>4.4.15</version>

--- a/tobago-example/tobago-example-demo/src/test/liberty/config/server.xml
+++ b/tobago-example/tobago-example-demo/src/test/liberty/config/server.xml
@@ -1,0 +1,37 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+<server>
+  <featureManager>
+    <feature>jakartaee-8.0</feature>
+  </featureManager>
+
+  <webApplication contextRoot="/" location="tobago-example-demo.war" type="war">
+    <application-bnd>
+      <security-role name="demo-admin">
+        <user name="admin"/>
+      </security-role>
+      <security-role name="demo-guest">
+        <user name="guest"/>
+      </security-role>
+    </application-bnd>
+  </webApplication>
+
+  <basicRegistry>
+    <user name="admin" password="admin"/>
+    <user name="guest" password="guest"/>
+  </basicRegistry>
+</server>


### PR DESCRIPTION
* add maven profile "liberty" for open-liberty
* start demo with "mvn package -Pliberty liberty:run"
* apache BVal dependency is now set explicit for jetty and tomcat