### PR TITLE
feat: open-liberty maven profile

### DIFF
--- a/tobago-example/pom.xml
+++ b/tobago-example/pom.xml
@@ -92,6 +92,17 @@
     </pluginManagement>
   </build>
 
+  <dependencyManagement>
+    <!-- todo: replace with implementation of bean validation 3.0 -->
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.bval</groupId>
+        <artifactId>bval-jsr</artifactId>
+        <version>2.0.6</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.myfaces.tobago</groupId>
@@ -346,6 +357,12 @@
           <artifactId>jakarta.enterprise.cdi-api</artifactId>
           <scope>compile</scope>
         </dependency>
+        <dependency>
+          <!-- todo: replace with implementation of bean validation 3.0 -->
+          <groupId>org.apache.bval</groupId>
+          <artifactId>bval-jsr</artifactId>
+          <scope>compile</scope>
+        </dependency>
       </dependencies>
     </profile>
 
@@ -455,6 +472,12 @@
           <artifactId>jakarta.enterprise.cdi-api</artifactId>
           <scope>compile</scope>
         </dependency>
+        <dependency>
+          <!-- todo: replace with implementation of bean validation 3.0 -->
+          <groupId>org.apache.bval</groupId>
+          <artifactId>bval-jsr</artifactId>
+          <scope>compile</scope>
+        </dependency>
         <!-- this enables the development mode -->
         <dependency>
           <groupId>org.apache.myfaces.tobago</groupId>
@@ -522,6 +545,41 @@
       </build>
     </profile>
 
+    <profile>
+      <id>liberty</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.openliberty.tools</groupId>
+            <artifactId>liberty-maven-plugin</artifactId>
+            <version>3.7.1</version>
+            <configuration>
+              <serverXmlFile>${project.basedir}/src/test/liberty/config/server.xml</serverXmlFile>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.myfaces.core</groupId>
+          <artifactId>myfaces-api</artifactId>
+          <version>${myfaces30.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.myfaces.core</groupId>
+          <artifactId>myfaces-impl</artifactId>
+          <version>${myfaces30.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <!-- this enables the development mode -->
+        <dependency>
+          <groupId>org.apache.myfaces.tobago</groupId>
+          <artifactId>tobago-config-dev</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
     <!--
     todo: profile for meecrowave?
     todo: profile for wildfly?

--- a/tobago-example/tobago-example-demo/pom.xml
+++ b/tobago-example/tobago-example-demo/pom.xml
@@ -207,11 +207,6 @@
       <artifactId>jakarta.validation-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.bval</groupId>
-      <artifactId>bval-jsr</artifactId>
-      <version>2.0.6</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
       <version>4.4.15</version>

--- a/tobago-example/tobago-example-demo/src/test/liberty/config/server.xml
+++ b/tobago-example/tobago-example-demo/src/test/liberty/config/server.xml
@@ -1,0 +1,37 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+<server>
+  <featureManager>
+    <feature>jakartaee-9.1</feature>
+  </featureManager>
+
+  <webApplication contextRoot="/" location="tobago-example-demo.war" type="war">
+    <application-bnd>
+      <security-role name="demo-admin">
+        <user name="admin"/>
+      </security-role>
+      <security-role name="demo-guest">
+        <user name="guest"/>
+      </security-role>
+    </application-bnd>
+  </webApplication>
+
+  <basicRegistry>
+    <user name="admin" password="admin"/>
+    <user name="guest" password="guest"/>
+  </basicRegistry>
+</server>


### PR DESCRIPTION
* add maven profile "liberty" for open-liberty
* start demo with "mvn package -Pliberty liberty:run"
* apache BVal dependency is now set explicit for jetty and tomcat
* add todo to replace apache BVal 2.0 with an implementation of bean validation 3.0