### PR TITLE
ci(dependabot): ignore TomEE 9 for Jakarta EE 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -147,6 +147,10 @@ updates:
       - dependency-name: "org.apache.maven.plugins:maven-enforcer-plugin"
         versions:
           - ">= 3.0.0"
+      # needs jakarta namespace
+      - dependency-name: "org.apache.tomee.maven:tomee-maven-plugin"
+        versions:
+          - ">= 9.0.0"
       # checkstyle 10 needs Java 11
       - dependency-name: "com.puppycrawl.tools:checkstyle"
         versions:


### PR DESCRIPTION
TomEE 9.0.0 is for Jakarta EE 9, so this must be ignored for Tobago 5.