### PR TITLE
fix: docker integration tests

### DIFF
--- a/tobago-example/tobago-example-demo/pom.xml
+++ b/tobago-example/tobago-example-demo/pom.xml
@@ -387,8 +387,19 @@
           <groupId>org.slf4j</groupId>
           <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
-
-        <!-- openwebbeans -->
+        <dependency>
+          <groupId>org.apache.openwebbeans</groupId>
+          <artifactId>openwebbeans-el22</artifactId>
+          <classifier>jakarta</classifier>
+          <version>${openwebbeans.version}</version>
+          <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>org.apache.openwebbeans</groupId>
+              <artifactId>*</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
         <dependency>
           <groupId>org.apache.openwebbeans</groupId>
           <artifactId>openwebbeans-jsf</artifactId>
@@ -454,7 +465,6 @@
             </exclusion>
           </exclusions>
         </dependency>
-
         <dependency>
           <groupId>org.apache.myfaces.tobago</groupId>
           <artifactId>tobago-config-owb</artifactId>

--- a/tobago-example/tobago-example-demo/src/main/docker/Dockerfile
+++ b/tobago-example/tobago-example-demo/src/main/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM tomcat:9.0-jdk11
+FROM tomcat:10-jdk11
 
 COPY tobago-example-demo.war /usr/local/tomcat/webapps/ROOT.war
 COPY tomcat-users.xml /usr/local/tomcat/conf/


### PR DESCRIPTION
* integration tests can be executed
* use tomcat:10 with java11
* use jakarta classifier for bval-jsr and owb

Issue: TOBAGO-2094