### PR TITLE
test: Intro

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/webapp/content/000-intro/Intro.test.js
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/000-intro/Intro.test.js
@@ -15,13 +15,15 @@
  * limitations under the License.
  */
 
-import {querySelectorFn} from "/script/tobago-test.js";
+import {elementByIdFn, querySelectorFn} from "/script/tobago-test.js";
 import {JasmineTestTool} from "/tobago/test/tobago-test-tool.js";
 
 it("First section title is 'Intro'", function (done) {
-  let titleOfFirstSectionHeader = querySelectorFn("tobago-section h1");
+  const titleOfFirstSectionHeader = querySelectorFn("tobago-section h1");
+  const introLinkFn = elementByIdFn("page:navigator:nav:1:cmd");
 
-  let test = new JasmineTestTool(done);
+  const test = new JasmineTestTool(done);
+  test.setup(() => titleOfFirstSectionHeader().textContent.trim() === "Intro", null, "click", introLinkFn);
   test.do(() => expect(titleOfFirstSectionHeader().textContent.trim()).toEqual("Intro"));
   test.start();
 });


### PR DESCRIPTION
Sometimes the title of Intro.xhtml is not set. This behavior is only for docker integration-tests in tomcat. Also, it's a special issue for the demo. A reload should fix this.