### PR TITLE
feature: custom body for tc:link/tc:button

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/CommandRendererBase.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/CommandRendererBase.java
@@ -142,7 +142,14 @@ public abstract class CommandRendererBase<T extends AbstractUICommand> extends D
     final String image = component.getImage();
     HtmlRendererUtils.encodeIconOrImage(writer, image);
 
-    if (label.getLabel() != null) {
+    final UIComponent labelFacet = ComponentUtils.getFacet(component, Facets.label);
+    if (labelFacet != null) {
+      insideBegin(facesContext, Facets.label);
+      for (final UIComponent child : RenderUtils.getFacetChildren(labelFacet)) {
+        child.encodeAll(facesContext);
+      }
+      insideEnd(facesContext, Facets.label);
+    } else if (label.getLabel() != null) {
       writer.startElement(HtmlElements.SPAN);
       HtmlRendererUtils.writeLabelWithAccessKey(writer, label);
       writer.endElement(HtmlElements.SPAN);


### PR DESCRIPTION
Add a label facet to tc:link and tc:button. If the label facet is used, the label attribute has no meaning and the content of the label facet is rendered inside the link/button.

Issue: TOBAGO-2203