### PR TITLE
fix(core): Avoid NPE in HtmlRendererUtils#writeDataAttributes

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/util/HtmlRendererUtils.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/util/HtmlRendererUtils.java
@@ -163,12 +163,24 @@ public final class HtmlRendererUtils {
 
     for (final Map.Entry<Object, Object> entry : dataAttributes.entrySet()) {
       final Object mapKey = entry.getKey();
-      final String name = mapKey instanceof ValueExpression
-          ? ((ValueExpression) mapKey).getValue(elContext).toString() : mapKey.toString();
+      final String name;
+      if (mapKey instanceof ValueExpression) {
+        Object expressionValue = ((ValueExpression) mapKey).getValue(elContext);
+        name = expressionValue != null ? expressionValue.toString() : null;
+      } else {
+        name = mapKey.toString();
+      }
       final Object mapValue = entry.getValue();
-      final String value = mapValue instanceof ValueExpression
-          ? ((ValueExpression) mapValue).getValue(elContext).toString() : mapValue.toString();
-      writer.writeAttribute(DataAttributes.dynamic(name), value, true);
+      final String value;
+      if (mapValue instanceof ValueExpression) {
+        Object expressionValue = ((ValueExpression) mapValue).getValue(elContext);
+        value = expressionValue !=null ? expressionValue.toString() : null;
+      } else {
+        value = mapValue.toString();
+      }
+      if (name != null && value != null) {
+        writer.writeAttribute(DataAttributes.dynamic(name), value, true);
+      }
     }
   }
 }


### PR DESCRIPTION
issue: TOBAGO-2244

```
java.lang.NullPointerException: Cannot invoke "Object.toString()" because the return value of "javax.el.ValueExpression.getValue(javax.el.ELContext)" is null
                at org.apache.myfaces.tobago.internal.util.HtmlRendererUtils.writeDataAttributes(HtmlRendererUtils.java:169) ~[tobago-core-5.7.2.jar:5.7.2]
```