### PR TITLE
fix(demo): remove f:verbatim

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/webapp/content/070-tab/01-ajax/Tab_Ajax.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/070-tab/01-ajax/Tab_Ajax.xhtml
@@ -59,17 +59,14 @@
       <tc:tab id="tabHead1" label="Only label">
         <p>Only a label is set.</p>
         <demo-highlight language="markup" id="tabHead1Code">&lt;tc:tab label="Only label"/></demo-highlight>
-        <f:verbatim><script type="text/javascript">Prism.highlightElement($('#tabHead1Code')[0]);</script></f:verbatim>
       </tc:tab>
       <tc:tab id="tabHead2" label="Label with image" image="#{request.contextPath}/image/feather-leaf.png">
         <p>A label and an image are set.</p>
         <demo-highlight language="markup" id="tabHead2Code">&lt;tc:tab label="Label with image" image="\#{request.contextPath}/image/feather-leaf.png"></demo-highlight>
-        <f:verbatim><script type="text/javascript">Prism.highlightElement($('#tabHead2Code')[0]);</script></f:verbatim>
       </tc:tab>
       <tc:tab id="tabHead3" image="#{request.contextPath}/image/feather-leaf.png">
         <p>Only an image is set.</p>
         <demo-highlight language="markup" id="tabHead3Code">&lt;tc:tab image="\#{request.contextPath}/image/feather-leaf.png"></demo-highlight>
-        <f:verbatim><script type="text/javascript">Prism.highlightElement($('#tabHead3Code')[0]);</script></f:verbatim>
       </tc:tab>
       <tc:tab id="tabHead4">
         <p>Neither a label or an image are set. In this case the header gets a label with the indexnumber of the tab in


### PR DESCRIPTION
f:verbatim was deprecated since JSF 2.0 and is now removed.