### PR TITLE
build: maven4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea/
-.mvn/
 *.iml
 *.ipr
 *.iws

--- a/pom.xml
+++ b/pom.xml
@@ -387,7 +387,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.4.1</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -501,6 +501,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>${maven-pmd-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-wrapper-plugin</artifactId>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -658,7 +663,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -714,6 +719,9 @@
               <!-- log files -->
               <exclude>**/*.log</exclude>
               <exclude>**/test-scenarios-locally/**/*</exclude>
+
+              <!-- git -->
+              <exclude>**/.gitkeep</exclude>
 
               <!-- maven -->
               <exclude>**/target/**/*</exclude>


### PR DESCRIPTION
Make Tobago compile with Maven 4.

* add .mvn directory to detect root
* update enforcer-plugin to latest version
* add maven-wrapper-plugin version
* update maven-source-plugin to 3.3.0 (only relevant for Tobago 6)