### PR TITLE
fix(demo): target attribute example

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/4000-button-link/Button_Link.test.js
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/4000-button-link/Button_Link.test.js
@@ -111,7 +111,7 @@ it("Target Link Link", function (done) {
 
 function getTargetFrameInput() {
   return elementByIdFn("page:mainForm:targetFrame")().contentWindow
-      .document.getElementById("textInput");
+      .document.getElementById("page:textInput::field");
 }
 
 it("Style must not be a dropdown item", function (done) {

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/4000-button-link/Button_Link.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/4000-button-link/Button_Link.xhtml
@@ -51,13 +51,13 @@
     <tc:buttons>
       <tc:button id="targetButtonAction" label="Action" action="#{buttonLinkController.targetActionPage}"
                  target="targetFrame"/>
-      <tc:button id="targetButtonLink" label="Link" outcome="/content/900-test/4000-button-link/x-targetLink.html"
+      <tc:button id="targetButtonLink" label="Link" outcome="/content/900-test/4000-button-link/x-targetLink.xhtml"
                  target="targetFrame"/>
     </tc:buttons>
     <tc:links>
       <tc:link id="targetLinkAction" label="Action" action="#{buttonLinkController.targetActionPage}"
                target="targetFrame"/>
-      <tc:link id="targetLinkLink" label="Link" outcome="/content/900-test/4000-button-link/x-targetLink.html"
+      <tc:link id="targetLinkLink" label="Link" outcome="/content/900-test/4000-button-link/x-targetLink.xhtml"
                target="targetFrame"/>
     </tc:links>
     <tc:box label="iframe">

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/4000-button-link/x-targetAction.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/4000-button-link/x-targetAction.xhtml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,14 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 -->
-<!DOCTYPE html
-        PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-  <title>TargetAction</title>
-</head>
-<body>
-<input id="textInput" value="accessed by action"/>
-</body>
-</html>
+
+<ui:composition template="/plain.xhtml"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:tc="http://myfaces.apache.org/tobago/component"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+  <tc:in id="textInput" value="accessed by action" readonly="true"/>
+</ui:composition>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/4000-button-link/x-targetLink.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/4000-button-link/x-targetLink.xhtml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,14 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 -->
-<!DOCTYPE html
-        PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-  <title>TargetLink</title>
-</head>
-<body>
-<input id="textInput" value="accessed by link"/>
-</body>
-</html>
+
+<ui:composition template="/plain.xhtml"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:tc="http://myfaces.apache.org/tobago/component"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+  <tc:in id="textInput" value="accessed by link" readonly="true"/>
+</ui:composition>


### PR DESCRIPTION
The x-target*.xhtml now contains JSF code (and not plain html).