### PR TITLE
chore(dependabot): checkstyle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,6 +81,10 @@ updates:
       - dependency-name: "jakarta.xml.bind:jakarta.xml.bind-api"
         versions:
           - ">= 5.0.0"
+      # Tobago 5 and 6 should use the same checkstyle version (checkstyle 10 needs Java 11, so Tobago 5 uses version 9)
+      - dependency-name: "com.puppycrawl.tools:checkstyle"
+        versions:
+          - ">= 10.0"
 
   - package-ecosystem: "maven"
     directory: "/"


### PR DESCRIPTION
Tobago 5 and 6 should use the same checkstyle version. Checkstyle 10 requires Java 11. Tobago 5 can be build with Java 8. Therefor Tobago 5 use Checkstyle 9.3 and Tobago 6 should use it too.