### PR TITLE
ci(github action): Docker integration tests

### DIFF
--- a/.github/workflows/ui-testing.yml
+++ b/.github/workflows/ui-testing.yml
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+
+name: Execute ui tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'zulu'
+
+      - name: Build all modules for integration test
+        run: mvn clean install
+
+      - name: Ui testing
+        run: |
+          cd tobago-example/tobago-example-demo
+          mvn verify -Pdocker -Pintegration-tests


### PR DESCRIPTION
* added a workflow to run ui tests for the tobago demo
* the workflow uses the "docker" and "integration-tests" as profile
* the workflow should be triggered manually, because the ui tests are currently unstable