### PR TITLE
chore: update to minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myfaces-tobago",
-  "version": "5.9.1-SNAPSHOT",
+  "version": "5.10.0-SNAPSHOT",
   "description": "The goal of Tobago is to provide the community with a well designed set of user interface components based on JSF and run on MyFaces.",
   "repository": {
     "type": "git",

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <artifactId>tobago</artifactId>
   <packaging>pom</packaging>
   <name>Apache Tobago</name>
-  <version>5.9.1-SNAPSHOT</version>
+  <version>5.10.0-SNAPSHOT</version>
   <description>The goal of Tobago is to provide the community with a well designed set of user interface components based on JSF and run on MyFaces.</description>
   <url>http://myfaces.apache.org/tobago</url>
   <inceptionYear>2002</inceptionYear>

--- a/tobago-assembly/pom.xml
+++ b/tobago-assembly/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/tobago-core/pom.xml
+++ b/tobago-core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <artifactId>tobago-core</artifactId>
   <packaging>jar</packaging>

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/package-info.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/package-info.java
@@ -25,6 +25,6 @@
     shortName = "tc",
     uri = "http://myfaces.apache.org/tobago/component",
     name = "tobago",
-    displayName = "Tobago Components 5.9.1-SNAPSHOT")
+    displayName = "Tobago Components 5.10.0-SNAPSHOT")
 
 package org.apache.myfaces.tobago.internal.taglib.component;

--- a/tobago-example/pom.xml
+++ b/tobago-example/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
   <name>Tobago Examples</name>

--- a/tobago-example/tobago-example-assembly/pom.xml
+++ b/tobago-example/tobago-example-assembly/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-example</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
 
   <profiles>

--- a/tobago-example/tobago-example-blank/pom.xml
+++ b/tobago-example/tobago-example-blank/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-example</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <artifactId>tobago-example-blank</artifactId>
   <packaging>${app.packaging}</packaging>

--- a/tobago-example/tobago-example-demo/package-lock.json
+++ b/tobago-example/tobago-example-demo/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tobago-example-demo",
-  "version": "5.9.1-SNAPSHOT",
+  "version": "5.10.0-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tobago-example-demo",
-      "version": "5.9.1-SNAPSHOT",
+      "version": "5.10.0-SNAPSHOT",
       "license": "Apache-2.0",
       "dependencies": {
         "font-awesome": "4.7.0",

--- a/tobago-example/tobago-example-demo/package.json
+++ b/tobago-example/tobago-example-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tobago-example-demo",
-  "version": "5.9.1-SNAPSHOT",
+  "version": "5.10.0-SNAPSHOT",
   "description": "The demo for the Tobago framework",
   "repository": {
     "type": "git",

--- a/tobago-example/tobago-example-demo/pom.xml
+++ b/tobago-example/tobago-example-demo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-example</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <artifactId>tobago-example-demo</artifactId>
   <packaging>${app.packaging}</packaging>

--- a/tobago-example/tobago-example-spring-boot/pom.xml
+++ b/tobago-example/tobago-example-spring-boot/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-example</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <artifactId>tobago-example-spring-boot</artifactId>
   <packaging>jar</packaging>

--- a/tobago-theme/package-lock.json
+++ b/tobago-theme/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tobago-theme",
-  "version": "5.9.1-SNAPSHOT",
+  "version": "5.10.0-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tobago-theme",
-      "version": "5.9.1-SNAPSHOT",
+      "version": "5.10.0-SNAPSHOT",
       "license": "Apache-2.0",
       "dependencies": {
         "@trevoreyre/autocomplete-js": "^2.4.1",

--- a/tobago-theme/package.json
+++ b/tobago-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tobago-theme",
-  "version": "5.9.1-SNAPSHOT",
+  "version": "5.10.0-SNAPSHOT",
   "description": "The themes of the Tobago framework",
   "repository": {
     "type": "git",

--- a/tobago-theme/pom.xml
+++ b/tobago-theme/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
   <name>Tobago Themes</name>

--- a/tobago-theme/tobago-theme-charlotteville/pom.xml
+++ b/tobago-theme/tobago-theme-charlotteville/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-theme</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <artifactId>tobago-theme-charlotteville</artifactId>
   <name>Tobago Theme Charlotteville</name>

--- a/tobago-theme/tobago-theme-roxborough/pom.xml
+++ b/tobago-theme/tobago-theme-roxborough/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-theme</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <artifactId>tobago-theme-roxborough</artifactId>
   <packaging>jar</packaging>

--- a/tobago-theme/tobago-theme-scarborough/pom.xml
+++ b/tobago-theme/tobago-theme-scarborough/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-theme</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <artifactId>tobago-theme-scarborough</artifactId>
   <packaging>jar</packaging>

--- a/tobago-theme/tobago-theme-speyside/pom.xml
+++ b/tobago-theme/tobago-theme-speyside/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-theme</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <artifactId>tobago-theme-speyside</artifactId>
   <packaging>jar</packaging>

--- a/tobago-theme/tobago-theme-standard/pom.xml
+++ b/tobago-theme/tobago-theme-standard/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-theme</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <artifactId>tobago-theme-standard</artifactId>
   <packaging>jar</packaging>

--- a/tobago-tool/pom.xml
+++ b/tobago-tool/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
   <name>Tobago Tool</name>

--- a/tobago-tool/tobago-config-dev/pom.xml
+++ b/tobago-tool/tobago-config-dev/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-tool</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tobago-config-dev</artifactId>

--- a/tobago-tool/tobago-config-mojarra/pom.xml
+++ b/tobago-tool/tobago-config-mojarra/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-tool</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tobago-config-mojarra</artifactId>

--- a/tobago-tool/tobago-config-myfaces/pom.xml
+++ b/tobago-tool/tobago-config-myfaces/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-tool</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tobago-config-myfaces</artifactId>

--- a/tobago-tool/tobago-config-owb/pom.xml
+++ b/tobago-tool/tobago-config-owb/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-tool</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tobago-config-owb</artifactId>

--- a/tobago-tool/tobago-tool-annotation/pom.xml
+++ b/tobago-tool/tobago-tool-annotation/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-tool</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <artifactId>tobago-tool-annotation</artifactId>
   <packaging>jar</packaging>

--- a/tobago-tool/tobago-tool-apt/pom.xml
+++ b/tobago-tool/tobago-tool-apt/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-tool</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <artifactId>tobago-tool-apt</artifactId>
   <packaging>jar</packaging>

--- a/tobago-tool/tobago-tool-test/pom.xml
+++ b/tobago-tool/tobago-tool-test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-tool</artifactId>
-    <version>5.9.1-SNAPSHOT</version>
+    <version>5.10.0-SNAPSHOT</version>
   </parent>
   <artifactId>tobago-tool-test</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
Update to minor version because of:
* https://issues.apache.org/jira/browse/TOBAGO-2272
* https://issues.apache.org/jira/browse/TOBAGO-2276