### PR TITLE
fix: Invalid warning message from TobagoConfigParser for some tags

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/config/TobagoConfigParser.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/config/TobagoConfigParser.java
@@ -288,6 +288,7 @@ public class TobagoConfigParser extends TobagoConfigEntityResolver {
       case BEFORE:
       case AFTER:
       case THEME_CONFIG:
+      case DECODE_LINE_FEED:
       case DEFAULT_THEME:
       case SUPPORTED_THEME:
       case THEME_COOKIE:
@@ -296,6 +297,7 @@ public class TobagoConfigParser extends TobagoConfigEntityResolver {
       case MARKUP:
       case CREATE_SESSION_SECRET:
       case CHECK_SESSION_SECRET:
+      case ENABLE_TOBAGO_EXCEPTION_HANDLER:
       case SECURITY_ANNOTATION:
       case PREVENT_FRAME_ATTACKS:
       case SET_NOSNIFF_HEADER:


### PR DESCRIPTION
issue: TOBAGO-2289

(cherry picked from commit bde20db229fe6bbdeb3141b9d9dcee98aa4c221c)