### PR TITLE
build(npm): cleanup

### DIFF
--- a/tobago-theme/rollup.config.mjs
+++ b/tobago-theme/rollup.config.mjs
@@ -22,7 +22,7 @@ import terser from "@rollup/plugin-terser";
 import commonjs from "@rollup/plugin-commonjs";
 
 export default {
-  input: 'tobago-theme-standard/src/main/ts/tobago-all.ts',
+  input: 'tobago-theme-standard/src/main/ts/tobago-init.ts',
   output: [
     {
       file: 'tobago-theme-standard/src/main/js/tobago.js',

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-init.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-init.ts
@@ -15,20 +15,19 @@
  * limitations under the License.
  */
 
+// custom elements
 import "./tobago-bar";
 import "./tobago-behavior";
-import "./tobago-behavior-mode";
-import "./tobago-collapsible-operation";
-import "./tobago-dropdown";
 import "./tobago-date";
+import "./tobago-dropdown";
 import "./tobago-file";
 import "./tobago-focus";
 import "./tobago-footer";
 import "./tobago-in";
 import "./tobago-messages";
 import "./tobago-overlay";
+import "./tobago-page";
 import "./tobago-panel";
-import "./tobago-polyfill";
 import "./tobago-popover";
 import "./tobago-popup";
 import "./tobago-range";
@@ -36,8 +35,8 @@ import "./tobago-reload";
 import "./tobago-scroll";
 import "./tobago-select-boolean-checkbox";
 import "./tobago-select-boolean-toggle";
-import "./tobago-select-many-list";
 import "./tobago-select-many-checkbox";
+import "./tobago-select-many-list";
 import "./tobago-select-many-listbox";
 import "./tobago-select-many-shuttle";
 import "./tobago-select-one-choice";
@@ -47,7 +46,6 @@ import "./tobago-select-one-radio";
 import "./tobago-sheet";
 import "./tobago-split-layout";
 import "./tobago-stars";
-import "./tobago-suggest";
 import "./tobago-tab";
 import "./tobago-textarea";
 import "./tobago-toasts";
@@ -55,6 +53,9 @@ import "./tobago-tree";
 import "./tobago-tree-listbox";
 import "./tobago-tree-node";
 import "./tobago-tree-select";
+
+//polyfill
+import "./tobago-polyfill";
 
 if (document.readyState === "loading") {
   document.addEventListener("DOMContentLoaded",

--- a/tobago-theme/tsconfig.json
+++ b/tobago-theme/tsconfig.json
@@ -9,19 +9,12 @@
     "sourceMap": true,
     "inlineSources": true,
     "removeComments": false,
-    "noEmitOnError": true,
-    "moduleResolution": "node",
-    "esModuleInterop": true
+    "noEmitOnError": true
   },
   "include": [
-//    "tobago-theme-standard/src/main/ts/tobago-all.ts",
-//    "tobago-theme-standard/src/main/ts/faces.d.ts",
     "tobago-theme-standard/src/main/ts/*.ts"
   ],
   "exclude": [
-    "node_modules",
-    "node",
-    "tobago-theme-standard/npm/dist"
-  ],
-  "_comment for moduleResolution": "this is to fix a compiler problem with @babel/types, see: https://github.com/microsoft/TypeScript/issues/11103"
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
We do not use "@babel/types" anymore, so the moduleResolution can be removed. Remove also the "tobago-theme-standard/npm/dist"-exclusion, because the path did not exist anymore. Cleanup imports in tobago-all.ts (now tobago-init.ts). There should only imports for custom elements and tobago-polyfill. Rename tobago-all (which doesn't import ALL TS) into tobago-init, because this is the entry point for all TypeScripts and the tobago.init event is dispatched here.