### PR TITLE
fix: tc:popup throws PropertyNotWriteableException

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUICollapsiblePanel.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUICollapsiblePanel.java
@@ -22,7 +22,12 @@ package org.apache.myfaces.tobago.internal.component;
 import org.apache.myfaces.tobago.component.Attributes;
 import org.apache.myfaces.tobago.component.Facets;
 import org.apache.myfaces.tobago.model.CollapseMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
+
+import javax.el.ELContext;
 import javax.el.ValueExpression;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
@@ -33,6 +38,8 @@ import javax.faces.context.FacesContext;
 public abstract class AbstractUICollapsiblePanel extends AbstractUIPanelBase {
 
   private transient Boolean submittedCollapsed;
+
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Override
   public void processDecodes(final FacesContext facesContext) {
@@ -105,7 +112,13 @@ public abstract class AbstractUICollapsiblePanel extends AbstractUIPanelBase {
     if (submittedCollapsed != null) {
       final ValueExpression valueExpression = getValueExpression(Attributes.collapsed.name());
       if (valueExpression != null) {
-        valueExpression.setValue(FacesContext.getCurrentInstance().getELContext(), submittedCollapsed);
+        ELContext elContext = FacesContext.getCurrentInstance().getELContext();
+        if (!valueExpression.isReadOnly(elContext)) {
+          valueExpression.setValue(elContext, submittedCollapsed);
+        } else {
+          LOG.warn("Component clientId={} ValueExpression of collapsed attribute is readonly. Can not process state.",
+              getClientId(FacesContext.getCurrentInstance()));
+        }
       } else {
         setCollapsed(submittedCollapsed);
       }


### PR DESCRIPTION
support readonly attribute for collapsed attribute issue: TOBAGO-2320

(cherry picked from commit 64f629ceef2a4976efd222b62b28d84afe65658c)