### PR TITLE
build(maven): spring-boot-module profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 # Apache Tobago
 
-
 ## Building
 
 You need Maven 3 (at least 3.0.4) and Java 8 or later to build Tobago.
@@ -83,7 +82,7 @@ Switch to **special** subdirectory and call Maven to run the demo:
 
 ```
 cd tobago-example/tobago-example-spring-boot
-mvn clean spring-boot:run
+mvn clean -Pspring-boot-module spring-boot:run
 ```
 
 Browse to the local URL http://localhost:8080/

--- a/tobago-example/pom.xml
+++ b/tobago-example/pom.xml
@@ -35,7 +35,6 @@
     <module>tobago-example-blank</module>
     <module>tobago-example-demo</module>
     <module>tobago-example-assembly</module>
-    <module>tobago-example-spring-boot</module>
   </modules>
 
   <build>
@@ -112,6 +111,12 @@
   </dependencies>
 
   <profiles>
+    <profile>
+      <id>spring-boot-module</id>
+      <modules>
+        <module>tobago-example-spring-boot</module>
+      </modules>
+    </profile>
 
     <profile>
       <id>dev</id>


### PR DESCRIPTION
* deactivate spring-boot example by default
* adjust readme

The support for Spring 5.3.x ended. CVEs would only be fixed in the commercial version. The spring-boot example module is now deactivated by default. It can be activated with the "spring-boot-module" profile.