### PR TITLE
chore: activate spring-boot example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,10 +52,10 @@
 
     <!-- Note: defined here in master pom, because of problems with enforcer plugin -->
     <jetty.version>11.0.24</jetty.version>
-    <tomcat.version>10.1.13</tomcat.version>
-    <joinfaces.version>5.1.3</joinfaces.version>
-    <spring-boot.version>3.1.3</spring-boot.version>
-    <spring.version>6.0.11</spring.version>
+    <tomcat.version>10.1.30</tomcat.version>
+    <joinfaces.version>5.1.12</joinfaces.version>
+    <spring-boot.version>3.3.4</spring-boot.version>
+    <spring.version>6.1.13</spring.version>
     <jackson.version>2.15.2</jackson.version>
   </properties>
 

--- a/tobago-example/pom.xml
+++ b/tobago-example/pom.xml
@@ -35,8 +35,7 @@
     <module>tobago-example-blank</module>
     <module>tobago-example-demo</module>
     <module>tobago-example-assembly</module>
-    <!-- Spring Boot 3 demo deactivated because it requires Java 17. -->
-<!--    <module>tobago-example-spring-boot</module>-->
+    <module>tobago-example-spring-boot</module>
   </modules>
 
   <build>

--- a/tobago-example/tobago-example-spring-boot/pom.xml
+++ b/tobago-example/tobago-example-spring-boot/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.myfaces.tobago</groupId>
     <artifactId>tobago-example</artifactId>
-    <version>6.5.0-SNAPSHOT</version>
+    <version>6.5.1-SNAPSHOT</version>
   </parent>
   <artifactId>tobago-example-spring-boot</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
As JDK 17 is now required, the spring-boot example can be activated by default. Several version numbers are updated.