### PR TITLE
Fixing flaky tests in TobagoResponseWriterUnitTest.java

### DIFF
--- a/tobago-core/src/test/java/org/apache/myfaces/tobago/webapp/TobagoResponseWriterUnitTest.java
+++ b/tobago-core/src/test/java/org/apache/myfaces/tobago/webapp/TobagoResponseWriterUnitTest.java
@@ -201,8 +201,8 @@ public class TobagoResponseWriterUnitTest extends AbstractTobagoTestBase {
     c.getPassThroughAttributes().put("type", "number");
     c.encodeAll(facesContext);
     Assertions.assertTrue(getLastWritten().trim().matches("<tobago-in id='id' class='tobago-auto-spacing'>\\s*"
-        + "<input name='id' id='id::field' class='form-control' (step='1' type='number'|type='number' step='1')\\s*>\\s*"
-        + "</tobago-in>"));
+        + "<input name='id' id='id::field' class='form-control' (step='1' type='number'|type='number' step='1')\\s*>"
+        + "\\s*</tobago-in>"));
   }
 
   @Test

--- a/tobago-core/src/test/java/org/apache/myfaces/tobago/webapp/TobagoResponseWriterUnitTest.java
+++ b/tobago-core/src/test/java/org/apache/myfaces/tobago/webapp/TobagoResponseWriterUnitTest.java
@@ -173,8 +173,9 @@ public class TobagoResponseWriterUnitTest extends AbstractTobagoTestBase {
     writer.writeAttribute(HtmlAttributes.VALUE.getValue(), "100", null);
     writer.endElement(HtmlElements.INPUT.getValue());
 
-    Assertions.assertEquals("\n<input value='100' step='1' type='number'>",
-        stringWriter.toString());
+    Assertions.assertTrue(stringWriter.toString().trim().matches(
+        "<input value='100' (step='1' type='number'|type='number' step='1')\\s*>"
+    ));
   }
 
   @Test
@@ -199,9 +200,9 @@ public class TobagoResponseWriterUnitTest extends AbstractTobagoTestBase {
     c.getPassThroughAttributes().put("step", 1);
     c.getPassThroughAttributes().put("type", "number");
     c.encodeAll(facesContext);
-    Assertions.assertEquals("\n<tobago-in id='id' class='tobago-auto-spacing'>\n"
-        + " <input name='id' id='id::field' class='form-control' step='1' type='number'>\n"
-        + "</tobago-in>", getLastWritten());
+    Assertions.assertTrue(getLastWritten().trim().matches("<tobago-in id='id' class='tobago-auto-spacing'>\\s*"
+        + "<input name='id' id='id::field' class='form-control' (step='1' type='number'|type='number' step='1')\\s*>\\s*"
+        + "</tobago-in>"));
   }
 
   @Test


### PR DESCRIPTION
### Description

This Pull Request fixes flakiness in the following tests in [`org.apache.myfaces.tobago.webapp.TobagoResponseWriterUnitTest`](https://github.com/apache/myfaces-tobago/blob/10b822a3b3faf97d6864ce81357f2339e272d78f/tobago-core/src/test/java/org/apache/myfaces/tobago/webapp/TobagoResponseWriterUnitTest.java#L45)

1. [`org.apache.myfaces.tobago.webapp.TobagoResponseWriterUnitTest#testPassthrough`](https://github.com/apache/myfaces-tobago/blob/10b822a3b3faf97d6864ce81357f2339e272d78f/tobago-core/src/test/java/org/apache/myfaces/tobago/webapp/TobagoResponseWriterUnitTest.java#L167)
2. [`org.apache.myfaces.tobago.webapp.TobagoResponseWriterUnitTest#testPassthroughInRenderer`](https://github.com/apache/myfaces-tobago/blob/10b822a3b3faf97d6864ce81357f2339e272d78f/tobago-core/src/test/java/org/apache/myfaces/tobago/webapp/TobagoResponseWriterUnitTest.java#L195)

This flakiness presents itself because these tests make string checks on the generated HTML code, where the ordering of the passThroughAttributes - step='1' and type='number' is non-deterministic. 

These tests throw the following errors when run using the [Nondex](https://github.com/TestingResearchIllinois/NonDex) plugin - 

```
[ERROR] Failures:
[ERROR]   TobagoResponseWriterUnitTest.testPassthrough:176 expected: <
<input value='100' step='1' type='number'>> but was: <
<input value='100' type='number' step='1'>>
[ERROR]   TobagoResponseWriterUnitTest.testPassthroughInRenderer:202 expected: <
<tobago-in id='id' class='tobago-auto-spacing'>
 <input name='id' id='id::field' class='form-control' step='1' type='number'>
</tobago-in>> but was: <
<tobago-in id='id' class='tobago-auto-spacing'>
 <input name='id' id='id::field' class='form-control' type='number' step='1'>
</tobago-in>>
```

### Fix

As the order of attributes within an HTML tag does not matter, this pull request fixes these tests by checking the generated HTML code against a String regex which accepts these two attributes in both possible orders.

### Alternative Approach

Another potential fix for these tests is to amend the logic within [`org.apache.myfaces.tobago.internal.webapp.TobagoResponseWriterBase#startElementInternal`](https://github.com/apache/myfaces-tobago/blob/main/path/to/TobagoResponseWriterBase.java) to handle the `passThroughAttributes` in a deterministic order. If the project logic requires these attributes to be handled in a specific order, this approach can be considered instead of the regex-based test fix.

I'd love to get your feedback on this pull request. Please let me know if you'd like to see any changes.

Thank you for your time and consideration!