### PR TITLE
build: jetty should fail fast, if no profile

### DIFF
--- a/tobago-example/pom.xml
+++ b/tobago-example/pom.xml
@@ -38,21 +38,6 @@
     <module>tobago-example-spring-boot</module>
   </modules>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>jetty-maven-plugin</artifactId>
-          <version>${jetty.version}</version>
-          <configuration>
-            <scan>5</scan>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -211,6 +196,10 @@
           <plugin>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-maven-plugin</artifactId>
+            <version>${jetty.version}</version>
+            <configuration>
+              <scan>5</scan>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/tobago-example/tobago-example-demo/pom.xml
+++ b/tobago-example/tobago-example-demo/pom.xml
@@ -120,36 +120,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-maven-plugin</artifactId>
-        <configuration>
-          <loginServices>
-            <loginService implementation="org.eclipse.jetty.security.HashLoginService">
-              <name>demo-realm</name>
-              <config>src/test/resources/realm.properties</config>
-            </loginService>
-          </loginServices>
-          <stopKey>stopKey</stopKey>
-          <stopPort>9999</stopPort>
-          <systemProperties>
-            <systemProperty>
-              <name>derby.stream.error.file</name>
-              <value>target/derby.log</value>
-            </systemProperty>
-          </systemProperties>
-          <!--
-            <webApp>
-              <contextPath>/example</contextPath>
-            </webApp>
-          -->
-          <webApp>
-            <resourceBases>${basedir}/src/main/webapp,${tobago-theme-standard-dir}/META-INF/resources</resourceBases>
-          </webApp>
-        </configuration>
-        <dependencies>
-        </dependencies>
-      </plugin>
-      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <excludes>
@@ -441,6 +411,41 @@
 
     <profile>
       <id>jetty</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-maven-plugin</artifactId>
+            <configuration>
+              <loginServices>
+                <loginService implementation="org.eclipse.jetty.security.HashLoginService">
+                  <name>demo-realm</name>
+                  <config>src/test/resources/realm.properties</config>
+                </loginService>
+              </loginServices>
+              <stopKey>stopKey</stopKey>
+              <stopPort>9999</stopPort>
+              <systemProperties>
+                <systemProperty>
+                  <name>derby.stream.error.file</name>
+                  <value>target/derby.log</value>
+                </systemProperty>
+              </systemProperties>
+              <!--
+                <webApp>
+                  <contextPath>/example</contextPath>
+                </webApp>
+              -->
+              <webApp>
+                <resourceBases>${basedir}/src/main/webapp,${tobago-theme-standard-dir}/META-INF/resources
+                </resourceBases>
+              </webApp>
+            </configuration>
+            <dependencies>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
       <dependencies>
         <dependency>
           <groupId>org.hibernate.validator</groupId>


### PR DESCRIPTION
fix: In Demo: When calling "mvn jetty:run" there is an exception, that is not very helpful to find out you have to
call "mvn jetty:run -Pjetty".
You need to activate the profile.
The new error message is much easier to interpret.