### PR TITLE
fix(icons): Remove warning

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/renderkit/css/Icons.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/renderkit/css/Icons.java
@@ -96,7 +96,6 @@ public enum Icons implements CssItem {
         if (PATTERN_FA.matcher(name).matches()) {
           return "fa " + name;
         }
-        LOG.warn("Unknown icon format for name: '" + name + "'");
         return null;
       }
     };


### PR DESCRIPTION
* Remove warning to log if "image" attribute is a URL

Issue: TOBAGO-2380
(cherry picked from commit 3da051730371616fba18ab290c9c5cfaaf30fb5b)