### PR TITLE
refactor(demo): show/hide 'Test' menu entry

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/NavigationState.java
+++ b/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/NavigationState.java
@@ -51,6 +51,7 @@ public class NavigationState implements Serializable {
   private TreeState state = new TreeState(new ExpandedState(1), new SelectedState());
 
   private boolean viewSource = false;
+  private boolean showTests = false;
 
   private String searchString;
   private List<NavigationNode> searchResult;
@@ -170,6 +171,14 @@ public class NavigationState implements Serializable {
 
   public void setViewSource(final boolean viewSource) {
     this.viewSource = viewSource;
+  }
+
+  public boolean isShowTests() {
+    return showTests;
+  }
+
+  public void setShowTests(boolean showTests) {
+    this.showTests = showTests;
   }
 
   public String getSearchString() {

--- a/tobago-example/tobago-example-demo/src/main/webapp/menu.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/menu.xhtml
@@ -68,6 +68,10 @@
                      immediate="true" rendered="#{facesContext.isProjectStage('Development')}"/>
             <tc:link label="Access all pages" outcome="/testAccessAllPages.xhtml" target="_blank"
                      immediate="true" rendered="#{facesContext.isProjectStage('Development')}"/>
+            <tc:selectBooleanCheckbox itemLabel="navigation entry"
+                                      value="#{navigationState.showTests}">
+              <tc:event/>
+            </tc:selectBooleanCheckbox>
           </tc:link>
 
           <tc:link label="Menu" omit="true">

--- a/tobago-example/tobago-example-demo/src/main/webapp/navigation.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/navigation.xhtml
@@ -22,9 +22,10 @@
   <tc:tree id="#{navigationId}" value="#{navigationTree.tree}" var="node" state="#{navigationState.state}">
     <tc:treeNode id="node">
       <tc:link
-              id="#{linkId}"
-              label="» #{node.label}"
-              outcome="#{node.outcome}"/>
+          id="#{linkId}"
+          label="» #{node.label}"
+          outcome="#{node.outcome}"
+          rendered="#{navigationState.showTests or (node.label != 'Test')}"/>
     </tc:treeNode>
   </tc:tree>
 </f:subview>


### PR DESCRIPTION
The "Test" menu navigation entry is now hidden by default. It can be shown by clicking on the "navigation entry" checkbox in the header "Test" menu.