### PR TITLE
build(deps): downgrade cargo-maven3-plugin

### DIFF
--- a/tobago-example/pom.xml
+++ b/tobago-example/pom.xml
@@ -235,7 +235,7 @@
             -->
             <groupId>org.codehaus.cargo</groupId>
             <artifactId>cargo-maven3-plugin</artifactId>
-            <version>1.10.18</version>
+            <version>1.10.17</version>
             <configuration>
               <container>
                 <containerId>tomcat10x</containerId>


### PR DESCRIPTION
Downgrade cargo-maven3-plugin to 1.10.17, because with 1.10.18 Tomcat with Java 17 doesn't start.