### PR TITLE
tobago-example: fix spelling in webapp content (#6160)

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/webapp/content/000-intro/30-whats-new/68-new-in-4-2/Tobago_4.2.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/000-intro/30-whats-new/68-new-in-4-2/Tobago_4.2.xhtml
@@ -32,7 +32,7 @@
   <tc:section label="New Features and Enhancements">
 
     <ul>
-      <li>Desktop-like vertial layout is possible (like in Tobago 2), use <code>markup="spread"</code></li>
+      <li>Desktop-like vertical layout is possible (like in Tobago 2), use <code>markup="spread"</code></li>
       <li>New component &lt;tc:badge/> <tc:badge value="badge"/></li>
       <li>&lt;tc:selectReference> is fixed</li>
       <li>Better compatibility with Mojarra</li>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/330-conversation/Conversation.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/330-conversation/Conversation.xhtml
@@ -23,7 +23,7 @@
                 xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
 
   <tc:badge markup="warning"
-            value="Warning: This example is turned off, because its not suppored in Quarkus!"/><br/>
+            value="Warning: This example is turned off, because its not supported in Quarkus!"/><br/>
 
   <p>This page show a simple example for the <code>@ConversationScoped</code> annotation.
     The <b>Conversationscope</b> is needed for situations when the controller must live longer than a single request,

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/4650-segmentLayout/Segment_Layout.test.js
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/4650-segmentLayout/Segment_Layout.test.js
@@ -17,7 +17,7 @@
 
 import {elementByIdFn, querySelectorAllFn} from "/script/tobago-test.js";
 
-it("Check DOM of segement layout", function () {
+it("Check DOM of segment layout", function () {
   const segmentLayout = elementByIdFn("page:mainForm:segmentLayout");
   const segLayoutIn = elementByIdFn("page:mainForm:segLayoutIn:in");
   const segLayoutOut = elementByIdFn("page:mainForm:segLayoutOut:out");


### PR DESCRIPTION
(cherry picked from commit b3bdc51d69b0756fcca710f3b7e92ccba7926fdc)