### PR TITLE
test: sheet column width

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/3000-sheet/20-sheet-column-width/Sheet_Column_Width.test.js
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/3000-sheet/20-sheet-column-width/Sheet_Column_Width.test.js
@@ -67,7 +67,7 @@ it("Only pixel values set", function (done) {
   const columnHeads = querySelectorAllFn("#page\\:mainForm\\:pixelOnly header table thead tr th");
 
   const test = new JasmineTestTool(done);
-  test.do(() => expect(getComputedStyle(columnHeads()[0]).width).toBe("10px"));
+  test.do(() => expect(getComputedStyle(columnHeads()[0]).width).toBe("100px"));
   test.do(() => expect(getComputedStyle(columnHeads()[1]).width).toBe("20px"));
   test.do(() => expect(getComputedStyle(columnHeads()[2]).width).toBe("30px"));
   test.start();

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/3000-sheet/20-sheet-column-width/Sheet_Column_Width.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/3000-sheet/20-sheet-column-width/Sheet_Column_Width.xhtml
@@ -40,7 +40,7 @@
   </tc:sheet>
 
   <tc:sheet id="pixelOnly" value="#{columnWidthController.solarList}" var="object" rows="2"
-            columns="10px 20px 30px">
+            columns="100px 20px 30px">
     <tc:column label="Name">
       <tc:out value="#{object.name}"/>
     </tc:column>


### PR DESCRIPTION
Adjust test to use defined values. The pixel only test set the first column to 10px width but the padding is already 16px wide. This result in different behavior for Chrome and Firefox.