### PR TITLE
misc: fix spelling

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/AjaxSpecialCharacterController.java
+++ b/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/AjaxSpecialCharacterController.java
@@ -33,7 +33,7 @@ public class AjaxSpecialCharacterController implements Serializable {
   }
 
   public String getString() {
-    return "SubstituteChar=“\u001A” Five=“5” SigleQuote=“\'” DoubleQuote=“\"” "
+    return "SubstituteChar=“\u001A” Five=“5” SingleQuote=“\'” DoubleQuote=“\"” "
         + "Micro=“µ” Euro=“€” Atom=“⚛” Guitar=“\uD83C\uDFB8”";
   }
 }

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/060-popup/Popup.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/060-popup/Popup.xhtml
@@ -115,7 +115,7 @@
   <tc:section label="Client side popup">
     <p>To create a client side popup, use <code>omit="true"</code> for buttons and
       set <code>collapsedMode="hidden"</code> for the popup.
-      The popup will be alread rendered on the page and is shown/hidden via CSS.</p>
+      The popup will be already rendered on the page and is shown/hidden via CSS.</p>
     <p>Be aware that elements only hidden by CSS are still validated! For example, a required input field in a
       hidden client side popup will be checked after submit.
       You have also to consider that the shown/hidden state is not given to the server.</p>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/220-locale/Locale.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/220-locale/Locale.xhtml
@@ -41,7 +41,7 @@
 
   <p>
     The localization of JSF works with Java resource bundles.
-    These bundles needs to be definded in the <code>faces-config.xml</code> under the
+    These bundles need to be defined in the <code>faces-config.xml</code> under the
     section <code>&lt;resource-bundle&gt;</code>.
   </p>
 
@@ -61,7 +61,7 @@
       Tobago comes with a resource bundle
       <code>org.apache.myfaces.tobago.context.TobagoResourceBundle</code> mapped to
       <code>tobagoResourceBundle</code>.
-      This bundle contails translated text fragments used by Tobago e. g.
+      This bundle contains translated text fragments used by Tobago e.g.
       for label of components.
       It's easy to expand this bundle to support more languages.
       </p>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/2400-popup/060-popup/Popup.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/2400-popup/060-popup/Popup.xhtml
@@ -39,7 +39,7 @@
     <tc:form id="form2">
       <p>To create a client side popup you have to know about <code>collapsedMode</code>.
         The mode indicated whether a collapsed popup should be rendered.
-        If <code>collapsedMode="absent"</code>, which is default, a hidden popup dialog will no be rendered.
+        If <code>collapsedMode="absent"</code>, which is default, a hidden popup dialog will not be rendered.
         If <code>collapsedMode="hidden"</code>, a hidden popup dialog will be rendered on the page, but hidden by CSS.
       </p>
       <p>Be careful with validations. For example, hidden required input fields will be validated after submit.</p>
@@ -53,7 +53,7 @@
         The attribute <code>name</code> must be set and can have the value 'show' and 'hide'
         which is to show and hide the popup, obviously.
         The other mandatory attribute is the <code>for</code> attribute.
-        It contain the ID of the popup on which the transition should be executed.</p>
+        It contains the ID of the popup on which the transition should be executed.</p>
 
       <demo-highlight language="markup">&lt;tc:button label="Open" omit="true">
   &lt;tc:operation name="show" for="clientPopup"/>
@@ -189,7 +189,7 @@
     <tc:badge markup="warning">!</tc:badge> missing content
   </tc:section>
 
-  <tc:section label="Popup opend after AJAX call">
+  <tc:section label="Popup opened after AJAX call">
     <tc:button label="Open Popup" immediate="true" id="ajaxButton">
       <tc:operation name="show" for="ajaxPopup"/>
       <f:ajax render="ajaxPopup" execute="ajaxPopup"/>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/6000-event/Event_1870.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/6000-event/Event_1870.xhtml
@@ -38,7 +38,7 @@
   <tc:panel>
     <tc:style customClass="demo-selected"/>
     <p>
-      This box will be diplayed with background color #ffddff, because of the CSS class ".demo-selected".
+      This box will be displayed with background color #ffddff, because of the CSS class ".demo-selected".
       The color is defined in the local file "style/demo.css".
     </p>
     <p>

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/60000-manual/4500-suggest/Suggest.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/900-test/60000-manual/4500-suggest/Suggest.xhtml
@@ -24,7 +24,7 @@
                 xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
 
   <tc:section label="Suggest Input - AJAX">
-    <p>The out component will show the selected value choosen from the suggest input field. Ajax case is covered and component is reloaded after valid selection.</p>
+    <p>The out component will show the selected value chosen from the suggest input field. Ajax case is covered and component is reloaded after valid selection.</p>
     <tc:out id="outBasic" label="Selection" value="#{suggestController.selection1}"/>
     <tc:in id="inBasic" value="#{suggestController.selection1}">
       <tc:suggest totalCount="10" query="#{suggestController.query}">
@@ -35,7 +35,7 @@
   </tc:section>
 
   <tc:section label="Suggest Input - No AJAX">
-    <p>The out component will show the selected value choosen from the suggest input field. Page is reloaded after selection.</p>
+    <p>The out component will show the selected value chosen from the suggest input field. Page is reloaded after selection.</p>
     <tc:out id="outTwo" label="Selection" value="#{suggestController.selection2}"/>
     <tc:in id="inTwo" value="#{suggestController.selection2}">
       <tc:suggest totalCount="10" query="#{suggestController.query}">

--- a/tobago-example/tobago-example-demo/src/main/webapp/js/jasmine.js
+++ b/tobago-example/tobago-example-demo/src/main/webapp/js/jasmine.js
@@ -7839,7 +7839,7 @@ getJasmineRequireObj().makePrettyPrinter = function(j$) {
     }
 
     append(value) {
-      // This check protects us from the rare case where an object has overriden
+      // This check protects us from the rare case where an object has overridden
       // `toString()` with an invalid implementation (returning a non-string).
       if (typeof value !== 'string') {
         value = Object.prototype.toString.call(value);

--- a/tobago-example/tobago-example-spring-boot/src/main/resources/META-INF/resources/content/000-intro/15-spring-boot/Spring_Boot.xhtml
+++ b/tobago-example/tobago-example-spring-boot/src/main/resources/META-INF/resources/content/000-intro/15-spring-boot/Spring_Boot.xhtml
@@ -25,7 +25,7 @@
   </p>
   <p>
     Quite all of the content comes from the sister project "tobago-example-demo" by a JAR dependency.
-    Only this page an the simple
+    Only this page and the simple
     <tc:link label="hello-spring.xhtml" link="#{request.contextPath}/hello-spring.xhtml"/>
     reside in this module.
   </p>
@@ -35,7 +35,7 @@
   </p>
   <ul>
     <li>The dependencies in the pom.xml for Tobago, Spring Boot and Joinfaces. In this
-    example, all depenencies are used, not the "starter" dependencies.</li>
+    example, all dependencies are used, not the "starter" dependencies.</li>
     <li>The class TobagoApplication.java</li>
     <li>Facelets and other web-resources in META-INF/resources</li>
     <li>META-INF/application.yml</li>


### PR DESCRIPTION
Fixing typos in the tobago examples

(cherry picked from commit ab6bfa7b1db5bff65a1b40d13e3e67a3737a333d)