### PR TITLE
fix(sheet): selectabled no-entries-message row

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SheetRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SheetRenderer.java
@@ -402,6 +402,7 @@ public class SheetRenderer<T extends AbstractUISheet> extends RendererBase<T> {
 
     final List<Integer> expandedValue = component.isTreeModel() ? new ArrayList<>() : null;
 
+    encodeTableHeader(facesContext, component, writer, columnWidths, columns, autoLayout);
     encodeTableBody(
         facesContext, component, writer, sheetId, selectable, columnWidths, selectedRows, columns, autoLayout,
         expandedValue);
@@ -435,11 +436,11 @@ public class SheetRenderer<T extends AbstractUISheet> extends RendererBase<T> {
     insideEnd(facesContext, HtmlElements.TOBAGO_SHEET);
   }
 
-  private void encodeTableBody(
+  private void encodeTableHeader(
       final FacesContext facesContext, final AbstractUISheet sheet,
-      final TobagoResponseWriter writer, final String sheetId, final Selectable selectable,
-      final List<Integer> columnWidths, final List<Integer> selectedRows, final List<AbstractUIColumnBase> columns,
-      final boolean autoLayout, final List<Integer> expandedValue) throws IOException {
+      final TobagoResponseWriter writer,
+      final List<Integer> columnWidths, final List<AbstractUIColumnBase> columns, final boolean autoLayout)
+      throws IOException {
 
     final boolean showHeader = sheet.isShowHeader();
     final Markup sheetMarkup = sheet.getMarkup() != null ? sheet.getMarkup() : Markup.NULL;
@@ -480,6 +481,18 @@ public class SheetRenderer<T extends AbstractUISheet> extends RendererBase<T> {
         writer.endElement(HtmlElements.HEADER);
       }
     }
+  }
+
+  private void encodeTableBody(
+      final FacesContext facesContext, final AbstractUISheet sheet,
+      final TobagoResponseWriter writer, final String sheetId, final Selectable selectable,
+      final List<Integer> columnWidths, final List<Integer> selectedRows, final List<AbstractUIColumnBase> columns,
+      final boolean autoLayout, final List<Integer> expandedValue) throws IOException {
+
+    final boolean showHeader = sheet.isShowHeader();
+    final Markup sheetMarkup = sheet.getMarkup() != null ? sheet.getMarkup() : Markup.NULL;
+
+    boolean nonLazyUpdate = !sheet.isLazyUpdate(facesContext);
     writer.startElement(HtmlElements.DIV);
     writer.writeClassAttribute(TobagoClass.BODY);
 
@@ -655,9 +668,13 @@ public class SheetRenderer<T extends AbstractUISheet> extends RendererBase<T> {
       }
     }
     sheet.setRowIndex(-1);
+    writer.endElement(HtmlElements.TBODY);
 
     if (emptySheet && showHeader) {
+      writer.startElement(HtmlElements.TFOOT);
       writer.startElement(HtmlElements.TR);
+      writer.writeClassAttribute(TobagoClass.NO__ENTRIES);
+
       int countColumns = 0;
       for (final UIColumn column : columns) {
         if (!(column instanceof AbstractUIRow)) {
@@ -683,9 +700,9 @@ public class SheetRenderer<T extends AbstractUISheet> extends RendererBase<T> {
         writer.endElement(HtmlElements.TD);
       }
       writer.endElement(HtmlElements.TR);
+      writer.endElement(HtmlElements.TFOOT);
     }
 
-    writer.endElement(HtmlElements.TBODY);
     writer.endElement(HtmlElements.TABLE);
     writer.endElement(HtmlElements.DIV);
   }

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/080-sheet/43-empty/Empty_Sheet.test.js
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/080-sheet/43-empty/Empty_Sheet.test.js
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {elementByIdFn, querySelectorFn} from "/script/tobago-test.js";
+import {JasmineTestTool} from "/tobago/test/tobago-test-tool.js";
+
+it("Default: No selection of empty-row-message", function (done) {
+  const sheet = elementByIdFn("page:mainForm:default");
+  const noEntriesRow = querySelectorFn("#page\\:mainForm\\:default .tobago-no-entries");
+
+  let rowSelectionChange = 0;
+  let clickNoEntriesRow = 0;
+
+  const test = new JasmineTestTool(done);
+  test.do(() => sheet().addEventListener("tobago.sheet.rowSelectionChange", () => rowSelectionChange++));
+  test.do(() => noEntriesRow().addEventListener("click", () => clickNoEntriesRow++));
+  test.event("click", noEntriesRow, () => clickNoEntriesRow >= 1);
+  test.do(() => expect(clickNoEntriesRow).toBe(1));
+  test.do(() => expect(rowSelectionChange).toBe(0));
+  test.start();
+});
+
+it("Custom: No selection of empty-row-message", function (done) {
+  const sheet = elementByIdFn("page:mainForm:facet");
+  const noEntriesRow = querySelectorFn("#page\\:mainForm\\:facet .tobago-no-entries");
+
+  let rowSelectionChange = 0;
+  let clickNoEntriesRow = 0;
+
+  const test = new JasmineTestTool(done);
+  test.do(() => sheet().addEventListener("tobago.sheet.rowSelectionChange", () => rowSelectionChange++));
+  test.do(() => noEntriesRow().addEventListener("click", () => clickNoEntriesRow++));
+  test.event("click", noEntriesRow, () => clickNoEntriesRow >= 1);
+  test.do(() => expect(clickNoEntriesRow).toBe(1));
+  test.do(() => expect(rowSelectionChange).toBe(0));
+  test.start();
+});


### PR DESCRIPTION
The no-entries-message row must not be selectable.

* add test
* fix

Refactoring: too many lines in the encodeTableBody() method. The table header is now encoded in the encodeTableHeader() metho.

Issue: TOBAGO-2419