### PR TITLE
fix(input group): before-facet

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/InRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/InRenderer.java
@@ -32,6 +32,7 @@ import org.apache.myfaces.tobago.internal.util.AccessKeyLogger;
 import org.apache.myfaces.tobago.internal.util.HtmlRendererUtils;
 import org.apache.myfaces.tobago.internal.util.StringUtils;
 import org.apache.myfaces.tobago.renderkit.css.BootstrapClass;
+import org.apache.myfaces.tobago.renderkit.css.CssItem;
 import org.apache.myfaces.tobago.renderkit.css.TobagoClass;
 import org.apache.myfaces.tobago.renderkit.html.HtmlAttributes;
 import org.apache.myfaces.tobago.renderkit.html.HtmlElements;
@@ -43,6 +44,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
 
 public class InRenderer<T extends AbstractUIIn> extends DecorationPositionRendererBase<T> {
 
@@ -56,6 +59,18 @@ public class InRenderer<T extends AbstractUIIn> extends DecorationPositionRender
   @Override
   public HtmlElements getComponentTag() {
     return HtmlElements.TOBAGO_IN;
+  }
+
+  @Override
+  protected CssItem[] getComponentCss(final FacesContext facesContext, final T component) {
+    List<CssItem> cssItems = new ArrayList<>();
+    if (component.isReadonly()) {
+      cssItems.add(TobagoClass.READONLY);
+    }
+    if (component.isDisabled()) {
+      cssItems.add(TobagoClass.DISABLED);
+    }
+    return cssItems.toArray(new CssItem[0]);
   }
 
   @Override

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/renderkit/css/TobagoClass.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/renderkit/css/TobagoClass.java
@@ -93,6 +93,7 @@ public enum TobagoClass implements CssItem {
   BUTTON__LEFT("tobago-button-left"),
   BUTTON__RIGHT("tobago-button-right"),
   RANGE("tobago-range"),
+  READONLY("tobago-readonly"),
   REQUIRED("tobago-required"),
   RESIZE("tobago-resize"),
   ROW__FILLER("tobago-row-filler"),

--- a/tobago-theme/src/main/scss/_tobago.scss
+++ b/tobago-theme/src/main/scss/_tobago.scss
@@ -848,6 +848,10 @@ tobago-image {
 tobago-in {
   display: block;
 
+  &.tobago-readonly {
+    //added because of TobagoClassUnitTest
+  }
+
   .input-group {
     > tobago-dropdown {
       /* fix corner styling, because tobago-dropdown use a surrounding container inside an input group */


### PR DESCRIPTION
Add a CSS class for readonly/disabled input groups to make CSS styling for the before-facet possible.

Issue: TOBAGO-2431