### PR TITLE
refactor: typescript file naming

### DIFF
--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-bar.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-bar.ts
@@ -16,7 +16,7 @@
  */
 
 import {Css} from "./tobago-css";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class Bar extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-behavior.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-behavior.ts
@@ -22,7 +22,7 @@ import {CollapseOperation} from "./tobago-collapse-operation";
 import {BehaviorMode} from "./tobago-behavior-mode";
 import {Overlay} from "./tobago-overlay";
 import {OverlayType} from "./tobago-overlay-type";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class Behavior extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-column-selector.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-column-selector.ts
@@ -19,7 +19,7 @@
 
 import {Sheet} from "./tobago-sheet";
 import {Selectable} from "./tobago-selectable";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 export class ColumnSelector {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-date.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-date.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class InputSupport {
 

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-dropdown-menu-static.test.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-dropdown-menu-static.test.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import {DropdownMenuStatic} from "./DropdownMenuStatic";
-import {DropdownMenuAlignment} from "../tobago-dropdown-menu";
+import {DropdownMenuStatic} from "./tobago-dropdown-menu-static";
+import {DropdownMenuAlignment} from "./tobago-dropdown-menu";
 
 test("getHorizontalPositionAndSize", () => {
   //reference element placed in the default content area of the page

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-dropdown-menu-static.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-dropdown-menu-static.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import {DropdownMenuAlignment} from "../tobago-dropdown-menu";
+import {DropdownMenuAlignment} from "./tobago-dropdown-menu";
 
 export class DropdownMenuStatic {
 

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-dropdown-menu.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-dropdown-menu.ts
@@ -17,7 +17,7 @@
 
 import {Css} from "./tobago-css";
 import {ClientBehaviors} from "./tobago-client-behaviors";
-import {DropdownMenuStatic} from "./dropdown/DropdownMenuStatic";
+import {DropdownMenuStatic} from "./tobago-dropdown-menu-static";
 
 export enum DropdownMenuAlignment {
   start,

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-dropdown.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-dropdown.ts
@@ -21,7 +21,7 @@ import {DropdownItem} from "./tobago-dropdown-item";
 import {DropdownItemFactory} from "./tobago-dropdown-item-factory";
 import {DropdownMenu, DropdownMenuAlignment} from "./tobago-dropdown-menu";
 import {ClientBehaviors} from "./tobago-client-behaviors";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 import {FocusableElement, tabbable} from "tabbable";
 
 class Dropdown extends HTMLElement {

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-event-listener-store.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-event-listener-store.ts
@@ -18,11 +18,11 @@
  */
 
 export class EventListenerStore {
-  private listeners: Array<{
+  private listeners: {
     element: EventTarget;
     type: string;
     listener: EventListenerOrEventListenerObject;
-  }> = [];
+  }[] = [];
 
   add(element: EventTarget, type: string, listener: EventListenerOrEventListenerObject): void {
     element.addEventListener(type, listener);

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-file.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-file.ts
@@ -18,7 +18,7 @@
 import {Overlay} from "./tobago-overlay";
 import {OverlayType} from "./tobago-overlay-type";
 import {Css} from "./tobago-css";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 export class File extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-footer.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-footer.ts
@@ -16,7 +16,7 @@
  */
 
 import {Css} from "./tobago-css";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class Footer extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-in.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-in.ts
@@ -17,7 +17,7 @@
 
 import {Focus} from "./tobago-focus";
 import {Suggest} from "./tobago-suggest";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 export class In extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-offcanvas.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-offcanvas.ts
@@ -18,7 +18,7 @@
 import {Offcanvas as BootstrapOffcanvas} from "bootstrap";
 import {BehaviorMode} from "./tobago-behavior-mode";
 import {Collapse} from "./tobago-collapse";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 const BootstrapOffcanvasEvent = {
   HIDE: "hide.bs.offcanvas",

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-page.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-page.ts
@@ -19,7 +19,7 @@ import {Overlay} from "./tobago-overlay";
 import {OverlayType} from "./tobago-overlay-type";
 import {Key} from "./tobago-key";
 import {PageStatic} from "./tobago-page-static";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 export class Page extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-paginator.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-paginator.ts
@@ -19,7 +19,7 @@ import {Key} from "./tobago-key";
 import {Overlay} from "./tobago-overlay";
 import {OverlayType} from "./tobago-overlay-type";
 import {Page} from "./tobago-page";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 export class TobagoPaginator extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-popup.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-popup.ts
@@ -18,7 +18,7 @@
 import {Modal} from "bootstrap";
 import {BehaviorMode} from "./tobago-behavior-mode";
 import {Collapse} from "./tobago-collapse";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 import {FocusableElement, tabbable} from "tabbable";
 import {Key} from "./tobago-key";
 

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-range.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-range.ts
@@ -16,7 +16,7 @@
  */
 
 import {Css} from "./tobago-css";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class TobagoRange extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-scroll.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-scroll.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class TobagoScroll extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-select-boolean-checkbox.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-select-boolean-checkbox.ts
@@ -16,7 +16,7 @@
  */
 
 import {Focus} from "./tobago-focus";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 export class SelectBooleanCheckbox extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-select-list-base.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-select-list-base.ts
@@ -20,7 +20,7 @@ import {TobagoFilterRegistry} from "./tobago-filter-registry";
 import {Key} from "./tobago-key";
 import {DropdownMenu, DropdownMenuAlignment} from "./tobago-dropdown-menu";
 import {Spinner} from "./tobago-spinner";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 export abstract class SelectListBase extends HTMLElement {
 

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-select-many-checkbox.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-select-many-checkbox.ts
@@ -16,7 +16,7 @@
  */
 
 import {Focus} from "./tobago-focus";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class SelectManyCheckbox extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-select-one-choice.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-select-one-choice.ts
@@ -16,7 +16,7 @@
  */
 
 import {Focus} from "./tobago-focus";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class SelectOneChoice extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-select-one-listbox.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-select-one-listbox.ts
@@ -16,7 +16,7 @@
  */
 
 import {Focus} from "./tobago-focus";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 export class SelectOneListbox extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-select-one-radio.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-select-one-radio.ts
@@ -17,7 +17,7 @@
 
 import {Focus} from "./tobago-focus";
 import {Key} from "./tobago-key";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class SelectOneRadio extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-sheet.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-sheet.ts
@@ -20,7 +20,7 @@ import {Css} from "./tobago-css";
 import {ClientBehaviors} from "./tobago-client-behaviors";
 import {ColumnSelector} from "./tobago-column-selector";
 import {Selectable} from "./tobago-selectable";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 interface MousemoveData {
   columnIndex: number;

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-split-layout.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-split-layout.ts
@@ -17,7 +17,7 @@
 
 import {Page} from "./tobago-page";
 import {Css} from "./tobago-css";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class SplitLayout extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-stars.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-stars.ts
@@ -16,7 +16,7 @@
  */
 
 import {Css} from "./tobago-css";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class Stars extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-suggest.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-suggest.ts
@@ -21,7 +21,7 @@ import {DropdownMenu, DropdownMenuAlignment} from "./tobago-dropdown-menu";
 import {Key} from "./tobago-key";
 import {ClientBehaviors} from "./tobago-client-behaviors";
 import {Spinner} from "./tobago-spinner";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 export class Suggest {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-tab.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-tab.ts
@@ -17,7 +17,7 @@
 
 import {Css} from "./tobago-css";
 import {ClientBehaviors} from "./tobago-client-behaviors";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class TabGroup extends HTMLElement {
 

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-textarea.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-textarea.ts
@@ -16,7 +16,7 @@
  */
 
 import {Focus} from "./tobago-focus";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class Textarea extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-tree-listbox.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-tree-listbox.ts
@@ -16,7 +16,7 @@
  */
 
 import {Css} from "./tobago-css";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 class TreeListbox extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-tree-node.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-tree-node.ts
@@ -18,7 +18,7 @@
 import {Sheet} from "./tobago-sheet";
 import {Tree} from "./tobago-tree";
 import {Css} from "./tobago-css";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 export class TreeNode extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-tree-select.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-tree-select.ts
@@ -18,7 +18,7 @@
 import {Selectable} from "./tobago-selectable";
 import {Tree} from "./tobago-tree";
 import {TreeNode} from "./tobago-tree-node";
-import {EventListenerStore} from "./util/EventListenerStore";
+import {EventListenerStore} from "./tobago-event-listener-store";
 
 export class TreeSelect extends HTMLElement {
   private listeners: EventListenerStore = new EventListenerStore();


### PR DESCRIPTION
Usual TypeScript file naming for EventListenerStore and DropdownMenuStatic.