### PR TITLE
fix(lazy-sheet): paging

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUISheet.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/component/AbstractUISheet.java
@@ -298,7 +298,7 @@ public abstract class AbstractUISheet extends AbstractUIData
    * @return Is panging needed to display all rows? If the number of rows is unknown this method returns true.
    */
   public boolean needMoreThanOnePage() {
-    if (isRowsUnlimited()) {
+    if (isRowsUnlimited() || isLazy()) {
       return false;
     } else if (!hasRowCount()) {
       return true;


### PR DESCRIPTION
Paging is no longer visible by default for lazy sheets, if using the (wrong) "rows" attribute instead of the (correct) "lazyRows" attribute.

Issue: TOBAGO-2520