### PR TITLE
fix(ajax queue): ajax event listener

### DIFF
--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-ajax-queue.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-ajax-queue.ts
@@ -44,12 +44,16 @@ class AjaxQueue {
 
     const currentOnEvent = options.onevent;
     options.onevent = (data: faces.AjaxEvent) => {
-      currentOnEvent(data);
+      if (currentOnEvent) {
+        currentOnEvent(data);
+      }
       this.ajaxEventListener(data.source, data.type, data.status);
     };
     const currentOnError = options.onerror;
     options.onerror = (data: faces.AjaxError) => {
-      currentOnError(data);
+      if (currentOnError) {
+        currentOnError(data);
+      }
       this.ajaxEventListener(data.source, data.type, data.status);
     };
 


### PR DESCRIPTION
The ajax event listener should be related to a specific ajax request. It should not be global.

Issue: TOBAGO-2521