### PR TITLE
refactor(behavior): new rules for ClientBehavior names

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/component/ClientBehaviors.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/component/ClientBehaviors.java
@@ -38,8 +38,12 @@ public enum ClientBehaviors {
   reload("reload"), // tbd - may be called timeout?
   resize("resize"),
   suggest("suggest"),
+  @Deprecated(since = "6.11.1", forRemoval = true)
   rowSelectionChange("tobago.sheet.rowSelectionChange"),
-  tabChange("tobago.tabGroup.tabChange");
+  sheetRowSelectionChange("tobago.sheet.rowSelectionChange"),
+  @Deprecated(since = "6.11.1", forRemoval = true)
+  tabChange("tobago.tabGroup.tabChange"),
+  tabGroupTabChange("tobago.tabGroup.tabChange");
 
   private final String jsEvent;
 
@@ -77,7 +81,11 @@ public enum ClientBehaviors {
   public static final String RELOAD = "reload"; // tbd - may be called timeout?
   public static final String RESIZE = "resize";
   public static final String SUGGEST = "suggest"; // tbd
-  public static final String ROW_SELECTION_CHANGE = "tobago.sheet.rowSelectionChange";
-  public static final String TAB_CHANGE = "tobago.tabGroup.tabChange";
+  public static final String SHEET_ROW_SELECTION_CHANGE = "tobago.sheet.rowSelectionChange";
+  @Deprecated(since = "6.11.1", forRemoval = true)
+  public static final String ROW_SELECTION_CHANGE = SHEET_ROW_SELECTION_CHANGE;
+  public static final String TAB_GROUP_TAB_CHANGE = "tobago.tabGroup.tabChange";
+  @Deprecated(since = "6.11.1", forRemoval = true)
+  public static final String TAB_CHANGE = TAB_GROUP_TAB_CHANGE;
 
 }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SheetRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SheetRenderer.java
@@ -120,10 +120,10 @@ public class SheetRenderer<T extends AbstractUISheet> extends RendererBase<T> im
     final AbstractUIColumnSelector columnSelector = sheet.getColumnSelector();
     if (columnSelector != null) {
       List<ClientBehavior> clientBehaviors =
-          columnSelector.getClientBehaviors().get(ClientBehaviors.ROW_SELECTION_CHANGE);
+          columnSelector.getClientBehaviors().get(ClientBehaviors.SHEET_ROW_SELECTION_CHANGE);
       if (clientBehaviors != null && !clientBehaviors.isEmpty()) {
         ClientBehavior clientBehavior = clientBehaviors.get(0);
-        sheet.addClientBehavior(ClientBehaviors.ROW_SELECTION_CHANGE, clientBehavior);
+        sheet.addClientBehavior(ClientBehaviors.SHEET_ROW_SELECTION_CHANGE, clientBehavior);
       }
     }
   }

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TabGroupRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TabGroupRenderer.java
@@ -78,7 +78,7 @@ public class TabGroupRenderer<T extends AbstractUITabGroup> extends RendererBase
 
     final AbstractUITabGroup tabGroup = (AbstractUITabGroup) event.getComponent();
     final FacesContext facesContext = FacesContext.getCurrentInstance();
-    final ClientBehaviors tabChange = ClientBehaviors.tabChange;
+    final ClientBehaviors tabChange = ClientBehaviors.tabGroupTabChange;
     final boolean immediate = tabGroup.isImmediate();
     switch (tabGroup.getSwitchType()) {
       case none:

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/ColumnSelectorTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/ColumnSelectorTagDeclaration.java
@@ -47,7 +47,7 @@ import org.apache.myfaces.tobago.model.Selectable;
         "jakarta.faces.component.behavior.ClientBehaviorHolder"
     },
     behaviors = {
-        @Behavior(name = ClientBehaviors.ROW_SELECTION_CHANGE, isDefault = true)
+        @Behavior(name = ClientBehaviors.SHEET_ROW_SELECTION_CHANGE, isDefault = true)
     },
     allowedChildComponents = "NONE")
 public interface ColumnSelectorTagDeclaration

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SheetTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/SheetTagDeclaration.java
@@ -70,7 +70,7 @@ import org.apache.myfaces.tobago.model.Selectable;
         @Behavior(
             name = ClientBehaviors.RELOAD, // XXX replace by click
             isDefault = true),
-        @Behavior(name = ClientBehaviors.ROW_SELECTION_CHANGE)
+        @Behavior(name = ClientBehaviors.SHEET_ROW_SELECTION_CHANGE)
     },
     markups = {
         @Markup(

--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/TabGroupTagDeclaration.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/taglib/component/TabGroupTagDeclaration.java
@@ -52,7 +52,7 @@ import jakarta.faces.component.UIPanel;
     rendererType = RendererTypes.TAB_GROUP,
     allowedChildComponents = "org.apache.myfaces.tobago.Tab",
     behaviors = {
-        @Behavior(name = ClientBehaviors.TAB_CHANGE, isDefault = true),
+        @Behavior(name = ClientBehaviors.TAB_GROUP_TAB_CHANGE, isDefault = true),
         @Behavior(name = ClientBehaviors.CLICK)
     },
     markups = {

--- a/tobago-core/src/test/java/org/apache/myfaces/tobago/util/EnumUnitTest.java
+++ b/tobago-core/src/test/java/org/apache/myfaces/tobago/util/EnumUnitTest.java
@@ -43,15 +43,18 @@ public abstract class EnumUnitTest {
     Assertions.assertEquals(fields.length, 2 * values.length, "Is for every enum a string constant defined?");
 
     for (final Field field : fields) {
+      if (field.isAnnotationPresent(Deprecated.class)) {
+        continue;
+      }
+
       final Object object = field.get(null);
       final String fieldName = field.getName();
-      if (object instanceof String) {
+      if (object instanceof String value) {
         // case String constant
-        String value = (String) object;
         final String expected = constantCaseToEnum(fieldName);
-        int index = value.lastIndexOf('.');
-        if (index > 0) {
-          value = value.substring(index+1);
+        if (value.startsWith("tobago.")) {
+          value = value.substring("tobago.".length());
+          value = convertToCamelCase(value);
         }
         Assertions.assertEquals(expected, value);
         Assertions.assertNotNull(enumType.getField(value), "exists");
@@ -61,6 +64,17 @@ public abstract class EnumUnitTest {
       } else {
         Assertions.fail();
       }
+    }
+  }
+
+  private String convertToCamelCase(final String value) {
+    final int index = value.indexOf(".");
+    if (index >= 0) {
+      return convertToCamelCase(value.substring(0, index)
+          + Character.toUpperCase(value.charAt(index + 1))
+          + value.substring(index + 2));
+    } else {
+      return value;
     }
   }
 }


### PR DESCRIPTION
Allow client behavior names with a dot. Like
  dropdownHide("tobago.dropdown.hide"),
  dropdownHidden("tobago.dropdown.hidden"),
  dropdownShow("tobago.dropdown.show"),
  dropdownShown("tobago.dropdown.shown"),

For this, ROW_SELECTION_CHANGE and TAB_CHANGE had to be renamed. Test adjusted. Change is backwards compatible.

This is a preparation for: TOBAGO-2526