### PR TITLE
ci(github): reactivate dependency check

### DIFF
--- a/.github/workflows/tobago-ci.yml
+++ b/.github/workflows/tobago-ci.yml
@@ -23,10 +23,13 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: '0 2 * * *'
   workflow_dispatch:
 
 jobs:
   build:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -46,7 +49,7 @@ jobs:
       - name: Build with Maven
 #         -DossindexAnalyzerEnabled=false to ignore Sonatype OSS (when it is out of order)
         run: |
-          if ! mvn -B checkstyle:check apache-rat:check dependency-check:check -Ddependency-check.skip=true -Pgenerate-assembly -Pfrontend package -Dformats=XML -f pom.xml; then
+          if ! mvn -B checkstyle:check apache-rat:check dependency-check:check -DautoUpdate=false -Pgenerate-assembly -Pfrontend package -Dformats=XML -f pom.xml; then
             find . \( -path '*/target/surefire-reports/*.xml' -o -path '*/target/failsafe-reports/*.xml' -o -path '*/target/rat.txt' -o -path '*/target/checkstyle-result.xml' -o -path '*/target/dependency-check-report.xml' \) | zip -q reports.zip -@
             exit 1
           fi
@@ -58,3 +61,24 @@ jobs:
           retention-days: 14
           path: reports.zip
           if-no-files-found: ignore
+
+  dependency-check-db-update:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Update Dependency-Check database
+        run: mvn -B dependency-check:update-only -f pom.xml


### PR DESCRIPTION
Use a dedicated update-job to update the dependency-check.

I think we will have to wait for reactivation on Jenkins until the NVD API is more stable.