### PR TITLE
ci(github): dependency check

### DIFF
--- a/.github/workflows/tobago-ci.yml
+++ b/.github/workflows/tobago-ci.yml
@@ -45,7 +45,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
         run: |
-          if ! mvn -B checkstyle:check apache-rat:check dependency-check:check -Pgenerate-assembly -Pfrontend package -Dformats=XML -f pom.xml; then
+          if ! mvn -B checkstyle:check apache-rat:check dependency-check:check -DautoUpdate=false -Pgenerate-assembly -Pfrontend package -Dformats=XML -f pom.xml; then
             find . \( -path '*/target/surefire-reports/*.xml' -o -path '*/target/failsafe-reports/*.xml' -o -path '*/target/rat.txt' -o -path '*/target/checkstyle-result.xml' -o -path '*/target/dependency-check-report.xml' \) | zip -q reports.zip -@
             exit 1
           fi


### PR DESCRIPTION
There is a separate job for the dependency check DB update. This job should nicht automatically update the DB.