### PR TITLE
refactor(demo): password check

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/ValidationController.java
+++ b/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/ValidationController.java
@@ -68,7 +68,18 @@ public class ValidationController implements Serializable {
     final String password = value.toString();
 
     final UIInput confirmationField = (UIInput) component.getAttributes().get("confirmationField");
-    final String confirmationFieldValue = confirmationField.getSubmittedValue().toString();
+    if (confirmationField == null) {
+      return;
+    }
+
+    String confirmationFieldValue;
+    final Object submitted = confirmationField.getSubmittedValue();
+    if (submitted != null) {
+      confirmationFieldValue = submitted.toString();
+    } else {
+      final Object current = confirmationField.getValue();
+      confirmationFieldValue = current.toString();
+    }
 
     if (password.isEmpty() || confirmationFieldValue.isEmpty()) {
       return;
@@ -76,7 +87,9 @@ public class ValidationController implements Serializable {
 
     if (!password.equals(confirmationFieldValue)) {
       confirmationField.setValid(false);
-      throw new ValidatorException(new FacesMessage("Passwords must match."));
+      final FacesMessage msg = new FacesMessage(FacesMessage.SEVERITY_WARN, "Passwords must match.", null);
+      facesContext.addMessage(confirmationField.getClientId(facesContext), msg);
+      facesContext.validationFailed();
     }
   }
 }

--- a/tobago-example/tobago-example-demo/src/main/webapp/content/170-validation/00/Content_Validation.xhtml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/content/170-validation/00/Content_Validation.xhtml
@@ -113,7 +113,7 @@
   </tc:section>
 
   <tc:section label="Two Field Validation">
-    <p>A validator check the password against the confirmation field.
+    <p>A validator compares the password against the confirmation field.
       To get access to the confirmation field from the validator a binding with the <code>binding</code> attribute
       and the <code class="language-markup">&lt;f:attribute/></code> tag is created.</p>
     <demo-highlight language="markup">&lt;tc:in label="Password" validator="\#{validationController.passwordValidator}">


### PR DESCRIPTION
Updated a Typo
Changed it so that the error message for "Password must match" is shown in the Confirmation Row instead of the Password