### PR TITLE
refactor(demo): password check

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/ValidationController.java
+++ b/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/ValidationController.java
@@ -86,7 +86,6 @@ public class ValidationController implements Serializable {
     }
 
     if (!password.equals(confirmationFieldValue)) {
-      confirmationField.setValid(false);
       final FacesMessage msg = new FacesMessage(FacesMessage.SEVERITY_WARN, "Passwords must match.", null);
       facesContext.addMessage(confirmationField.getClientId(facesContext), msg);
       facesContext.validationFailed();


### PR DESCRIPTION
Updated a Typo
Changed it so that the error message for "Password must match" is shown in the Confirmation Row instead of the Password