### PR TITLE
fix(upload): whitespace under input field

### DIFF
--- a/tobago-theme/src/main/scss/_tobago.scss
+++ b/tobago-theme/src/main/scss/_tobago.scss
@@ -668,6 +668,13 @@ tobago-file {
   > .input-group, tobago-progress {
     flex: 1 0 0px;
   }
+
+  .input-group {
+    > .form-control-sm ~ .input-group-text {
+      padding: .25rem .5rem;
+      font-size: .875rem;
+    }
+  }
 }
 
 /* flexLayout -------------------------------------------------------------- */

--- a/tobago-theme/src/main/scss/_tobago.scss
+++ b/tobago-theme/src/main/scss/_tobago.scss
@@ -671,8 +671,8 @@ tobago-file {
 
   .input-group {
     > .form-control-sm ~ .input-group-text {
-      padding: .25rem .5rem;
-      font-size: .875rem;
+      padding: $input-padding-y-sm $input-padding-x-sm;
+      @include font-size($input-font-size-sm);
     }
   }
 }


### PR DESCRIPTION
added some lines in the _tobago.scss so that the input field and the folder button are the same height, therefore removing the whitespace underneath the input