### PR TITLE
fix(tc:event): behavior on input fields

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TobagoClientBehaviorRenderer.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/TobagoClientBehaviorRenderer.java
@@ -132,6 +132,9 @@ public class TobagoClientBehaviorRenderer extends jakarta.faces.render.ClientBeh
           transition = event.isTransition();
           target = event.getTarget();
           clientId = event.getClientId(facesContext);
+          if (uiComponent instanceof SupportFieldId) {
+            fieldId = ((SupportFieldId) uiComponent).getFieldId(facesContext);
+          }
           if (collapse == null) {
             collapse = createCollapsible(facesContext, event);
           }

--- a/tobago-theme/tobago-theme-standard/src/main/ts/tobago-behavior.ts
+++ b/tobago-theme/tobago-theme-standard/src/main/ts/tobago-behavior.ts
@@ -171,7 +171,7 @@ class Behavior extends HTMLElement {
     const page = Page.page(this);
     if (!page.submitActive) {
       page.submitActive = true;
-      const actionId = this.fieldId != null ? this.fieldId : this.clientId;
+      const actionId = this.clientId;
       const form = page.form;
       const oldTarget = form.getAttribute("target");
       const sourceHidden = document.getElementById("jakarta.faces.source") as HTMLInputElement;


### PR DESCRIPTION
Add a fieldId for tc:event tobago-behavior tags to identify a field element. If there is a field element, the JavaScript event must be dispatched from the field element. The client id is always the actionId for submits.

Issue: TOBAGO-2536