### PR TITLE
ci(Jenkins): dependency check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,9 +59,6 @@ pipeline {
 
                 stages {
                     stage('BuildAndTest') {
-                        environment {
-                            NIST_NVD_API_KEY = credentials('NIST_NVD_API_KEY')
-                        }
                         steps {
                             sh "mvn clean package checkstyle:check apache-rat:check dependency-check:check -Pgenerate-assembly -Pfrontend -DnvdApiKeyEnvironmentVariable=NIST_NVD_API_KEY"
                         }


### PR DESCRIPTION
Dependency check still don't work on Jenkins. The API seems to be correct but there are no CVE updates. Try to delete the "environment"-part because the Jenkinsfile for jackrabbit-filevault doesn't have this either.