### PR TITLE
Build(jsf.js_next_gen):

### DIFF
--- a/tobago-theme/package.json
+++ b/tobago-theme/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "bootstrap": "5.3.8",
     "bootstrap-icons": "1.13.1",
-    "jsf.js_next_gen": "4.1.0-beta.22",
+    "jsf.js_next_gen": "4.1.1",
     "lit-html": "3.3.3",
     "tabbable": "^6.5.0"
   },


### PR DESCRIPTION
build(deps): jsf.js_next_gen

Updated jsf.js_next_gen from 4.1.0-beta.22 to 4.1.1