### PR TITLE
ci(github): dependency check

### DIFF
--- a/.github/workflows/dependency-check-update.yml
+++ b/.github/workflows/dependency-check-update.yml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Dependency-Check DB Update
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  dependency-check-db-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Set up JDK 21
+        uses: actions/setup-java@v6.0.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Cache Maven packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Update Dependency-Check database
+        run: mvn -B dependency-check:update-only -DnvdApiKey=${{ secrets.NIST_NVD_API_KEY }} -f pom.xml


### PR DESCRIPTION
Separate job for updating dependency check DB, so a manual update is possible.

Add a separate job for the branch "tobago-4.x" because the action/cache mechanism prefers a cache from the same branch. If the CVE update job is only in the main branch available, the dependency-check might have outdated data in the tobago-4.x branch.