### PR TITLE
ci(github): maven repository caching

### DIFF
--- a/.github/workflows/dependency-check-update.yml
+++ b/.github/workflows/dependency-check-update.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Cache Maven packages
         uses: actions/cache@v6
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-repository-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: ${{ runner.os }}-m2-repository-
       - name: Update Dependency-Check database
         run: mvn -B dependency-check:update-only -DnvdApiKey=${{ secrets.NIST_NVD_API_KEY }} -f pom.xml

--- a/.github/workflows/tobago-ci.yml
+++ b/.github/workflows/tobago-ci.yml
@@ -40,9 +40,9 @@ jobs:
       - name: Cache Maven packages
         uses: actions/cache@v6
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-repository-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: ${{ runner.os }}-m2-repository-
       - name: Build with Maven
 #         -DossindexAnalyzerEnabled=false to ignore Sonatype OSS (when it is out of order)
         run: |

--- a/.github/workflows/ui-testing.yml
+++ b/.github/workflows/ui-testing.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Cache Maven packages
         uses: actions/cache@v6
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-repository-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: ${{ runner.os }}-m2-repository-
       - name: Ui testing
         run: mvn clean verify -Pdocker -Pintegration-tests


### PR DESCRIPTION
Currently, there is a dependency-check-update job which should update the CVE-DB every night. But it seems this does not work well. Caches are immutable. So caches with the same name will not override, even if there was a CVE-DB update.

So I think the cache name should be unique. And with the restore-key the latest cache will be used as a base. Before, the cache name was based on the pom.xml-hash. Now the name is generated from the runner-id and the run_attempt.

Another issue might be that the .m2 directory is completely cached. But it should be the .m2/repository directory. The setup-files can be generated every time from the Maven build.

The restore-key should end with "-" (says the AI...).