### PR TITLE
build(dependabot): don't update MyFaces major/minor version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,13 +71,19 @@ updates:
       - dependency-name: "org.glassfish:jakarta.faces"
         versions:
           - ">= 5.0.0"
-      # MyFaces 4.0 is Jakarta EE 10 Faces 4.0
+      # Stay on MyFaces 4.0.x which is Jakarta EE 10 which includes Faces 4.0
       - dependency-name: "org.apache.myfaces.core:myfaces-api"
-        versions:
-          - ">= 4.1.0"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
       - dependency-name: "org.apache.myfaces.core:myfaces-impl"
-        versions:
-          - ">= 4.1.0"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "org.apache.myfaces.core:myfaces-test"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
       # Mojarra 4.0 is Jakarta EE 10 Faces 4.0
       - dependency-name: "org.glassfish:jakarta.faces"
         versions:
@@ -94,17 +100,6 @@ updates:
       - dependency-name: "org.apache.tomcat:tomcat-jasper-el"
         versions:
           - ">= 11.0.0"
-      # Stay on MyFaces 4.0.x which is Jakarta EE 10 (this includes myfaces-api/impl/test
-      - dependency-name: "org.apache.myfaces.core:myfaces-api"
-        versions:
-          - ">= 4.1.0"
-      - dependency-name: "org.apache.myfaces.core:myfaces-impl"
-        versions:
-          - ">= 4.1.0"
-      - dependency-name: "org.apache.myfaces.core:myfaces-test"
-        versions:
-          - ">= 4.1.0"
-
   - package-ecosystem: "maven"
     directory: "/"
     target-branch: "tobago-4.x"


### PR DESCRIPTION
Dependabot created a PR for MyFaces 4.1.4, but the current dependabot.yml should prevent that.

* delete duplicated myfaces entry
* use "update-types" instead of "versions"