### PR TITLE
build: fix maven-failsafe-plugin

### DIFF
--- a/tobago-example/tobago-example-demo/pom.xml
+++ b/tobago-example/tobago-example-demo/pom.xml
@@ -251,7 +251,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <includes>
-                <include>integration/*</include>
+                <include>**/integration/*</include>
               </includes>
             </configuration>
             <executions>


### PR DESCRIPTION
With version 3.6.0, the package path pattern changed.