### PR TITLE
build(docker): fix open-liberty

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/webapp/WEB-INF/web.xml
+++ b/tobago-example/tobago-example-demo/src/main/webapp/WEB-INF/web.xml
@@ -79,6 +79,12 @@
     <param-value>url</param-value>
   </context-param>
 
+  <context-param>
+    <!-- fix Docker Open Liberty, which don't scan the "/WEB-INF/classes/META-INF/" directory -->
+    <param-name>jakarta.faces.FACELETS_LIBRARIES</param-name>
+    <param-value>/WEB-INF/classes/META-INF/tobago-example-demo.taglib.xml</param-value>
+  </context-param>
+
   <listener>
     <listener-class>org.apache.myfaces.tobago.example.demo.info.ActivitySessionListener</listener-class>
   </listener>


### PR DESCRIPTION
Open Liberty in Docker didn't read /WEB-INF/classes/META-INF/tobago-example-demo.taglib.xml automatically. This results in an error when opening a page which uses xmlns:demo="http://myfaces.apache.org/tobago/example/demo"